### PR TITLE
Changing the order of the Pagination commands to avoid error

### DIFF
--- a/src/Finder/ShopProductsFinder.php
+++ b/src/Finder/ShopProductsFinder.php
@@ -53,7 +53,6 @@ final class ShopProductsFinder implements ShopProductsFinderInterface
         $query->addSort($data[SortDataHandlerInterface::SORT_INDEX]);
 
         $products = $this->productFinder->findPaginated($query);
-
         $products->setMaxPerPage($data[PaginationDataHandlerInterface::LIMIT_INDEX]);
         $products->setCurrentPage($data[PaginationDataHandlerInterface::PAGE_INDEX]);
 

--- a/src/Finder/ShopProductsFinder.php
+++ b/src/Finder/ShopProductsFinder.php
@@ -54,8 +54,8 @@ final class ShopProductsFinder implements ShopProductsFinderInterface
 
         $products = $this->productFinder->findPaginated($query);
 
-        $products->setCurrentPage($data[PaginationDataHandlerInterface::PAGE_INDEX]);
         $products->setMaxPerPage($data[PaginationDataHandlerInterface::LIMIT_INDEX]);
+        $products->setCurrentPage($data[PaginationDataHandlerInterface::PAGE_INDEX]);
 
         return $products;
     }


### PR DESCRIPTION
Changing the order of the Pagination commands to avoid error as explained here: https://github.com/whiteoctober/Pagerfanta/pull/71
I had this error out of the box when using the Plugin.