### PR TITLE
Fixes option taxon indexation when multiple products have values

### DIFF
--- a/src/PropertyBuilder/OptionTaxonsBuilder.php
+++ b/src/PropertyBuilder/OptionTaxonsBuilder.php
@@ -106,7 +106,11 @@ final class OptionTaxonsBuilder extends AbstractBuilder
             $product = $productVariant->getProduct();
 
             if ($documentProductOption === $option && $product->isEnabled()) {
-                $taxons = $this->productTaxonsMapper->mapToUniqueCodes($product);
+                foreach ($this->productTaxonsMapper->mapToUniqueCodes($product) as $taxon) {
+                    if (!in_array($taxon, $taxons)) {
+                        $taxons[] = $taxon;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The taxons indexed for any given options were overriden with the taxons of each product having a value for at least one variant of that option in BitBag\SyliusElasticsearchPlugin\PropertyBuilder\OptionTaxonsBuilder

This fixes the issue by concatenating the prudcts taxons instead.

Initial problem can be reproduced this way:
- Create a product with a taxon and an option
- Create a product with another taxon and the same option
- Go to /products-list/taxon and /products-list/another_taxon

Filters for the option appear on only one of the pages.