### PR TITLE
OOM Fix during index population

### DIFF
--- a/spec/PropertyBuilder/AttributeTaxonsBuilderSpec.php
+++ b/spec/PropertyBuilder/AttributeTaxonsBuilderSpec.php
@@ -12,24 +12,22 @@ declare(strict_types=1);
 
 namespace spec\BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
+use BitBag\SyliusElasticsearchPlugin\EntityRepository\TaxonRepository;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AttributeTaxonsBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\Mapper\ProductTaxonsMapperInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use FOS\ElasticaBundle\Event\TransformEvent;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Product\Repository\ProductAttributeValueRepositoryInterface;
 
 final class AttributeTaxonsBuilderSpec extends ObjectBehavior
 {
     function let(
-        ProductAttributeValueRepositoryInterface $productAttributeValueRepository,
+        TaxonRepository $bitbagTaxonRepository,
         ProductTaxonsMapperInterface $productTaxonsMapper
     ): void {
         $this->beConstructedWith(
-            $productAttributeValueRepository,
-            $productTaxonsMapper,
-            'attribute',
+            $bitbagTaxonRepository,
             'taxons'
         );
     }

--- a/src/EntityRepository/TaxonRepository.php
+++ b/src/EntityRepository/TaxonRepository.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BitBag\SyliusElasticsearchPlugin\EntityRepository;
+
+use Doctrine\ORM\Query\Expr\Join;
+use Sylius\Bundle\CoreBundle\Doctrine\ORM\ProductRepository;
+use Sylius\Bundle\TaxonomyBundle\Doctrine\ORM\TaxonRepository as BaseTaxonRepository;
+use Sylius\Component\Attribute\Model\AttributeInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface as BaseTaxonRepositoryInterface;
+
+class TaxonRepository implements TaxonRepositoryInterface
+{
+    /**
+     * @var BaseTaxonRepository
+     */
+    protected $taxonRepository;
+
+    /**
+     * @var ProductRepository
+     */
+    protected $productRepository;
+
+    /**
+     * @var string
+     */
+    protected $productTaxonEntityClass;
+
+    /**
+     * @var string
+     */
+    protected $productAttributeEntityClass;
+
+    /**
+     * TaxonRepository constructor.
+     *
+     * @param BaseTaxonRepositoryInterface $taxonRepository
+     * @param ProductRepositoryInterface   $productRepository
+     * @param string                       $productTaxonEntityClass
+     * @param string                       $productAttributeEntityClass
+     */
+    public function __construct(
+        BaseTaxonRepositoryInterface $taxonRepository,
+        ProductRepositoryInterface $productRepository,
+        string $productTaxonEntityClass,
+        string $productAttributeEntityClass
+    ) {
+        $this->taxonRepository             = $taxonRepository;
+        $this->productRepository           = $productRepository;
+        $this->productTaxonEntityClass     = $productTaxonEntityClass;
+        $this->productAttributeEntityClass = $productAttributeEntityClass;
+    }
+
+    /**
+     * @param AttributeInterface $attribute
+     *
+     * @return array|TaxonInterface[]
+     */
+    public function getTaxonsByAttributeViaProduct(AttributeInterface $attribute): array
+    {
+        return $this->taxonRepository
+            ->createQueryBuilder('t')
+            ->distinct(true)
+            ->select('t')
+            ->leftJoin($this->productTaxonEntityClass, 'pt', Join::WITH, 'pt.taxon = t.id')
+            ->where(
+                'pt.product IN(' .
+                $this
+                    ->productRepository->createQueryBuilder('p')
+                    ->leftJoin($this->productAttributeEntityClass, 'pav', Join::WITH, 'pav.subject = p.id')
+                    ->where('pav.attribute = :attribute')
+                    ->getQuery()
+                    ->getDQL()
+                . ')'
+            )
+            ->setParameter(':attribute', $attribute)
+            ->getQuery()
+            ->getResult();
+    }
+
+}

--- a/src/EntityRepository/TaxonRepositoryInterface.php
+++ b/src/EntityRepository/TaxonRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BitBag\SyliusElasticsearchPlugin\EntityRepository;
+
+use Sylius\Component\Attribute\Model\AttributeInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+
+interface TaxonRepositoryInterface
+{
+
+    /**
+     * @param AttributeInterface $attribute
+     *
+     * @return array|TaxonInterface[]
+     */
+    public function getTaxonsByAttributeViaProduct(AttributeInterface $attribute): array;
+}

--- a/src/PropertyBuilder/AttributeTaxonsBuilder.php
+++ b/src/PropertyBuilder/AttributeTaxonsBuilder.php
@@ -8,33 +8,20 @@
  * an email on mikolaj.krol@bitbag.pl.
  */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
-use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\Mapper\ProductTaxonsMapperInterface;
+use BitBag\SyliusElasticsearchPlugin\EntityRepository\TaxonRepository as BitbagTaxonRepository;
 use FOS\ElasticaBundle\Event\TransformEvent;
 use Sylius\Component\Attribute\Model\AttributeInterface;
-use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Product\Model\ProductAttributeValueInterface;
-use Sylius\Component\Product\Repository\ProductAttributeValueRepositoryInterface;
 
 final class AttributeTaxonsBuilder extends AbstractBuilder
 {
     /**
-     * @var ProductAttributeValueRepositoryInterface
+     * @var BitbagTaxonRepository
      */
-    private $productAttributeValueRepository;
-
-    /**
-     * @var ProductTaxonsMapperInterface
-     */
-    private $productTaxonsMapper;
-
-    /**
-     * @var string
-     */
-    private $attributeProperty;
+    protected $bitbagTaxonRepository;
 
     /**
      * @var string
@@ -47,24 +34,18 @@ final class AttributeTaxonsBuilder extends AbstractBuilder
     private $excludedAttributes;
 
     /**
-     * @param ProductAttributeValueRepositoryInterface $productAttributeValueRepository
-     * @param ProductTaxonsMapperInterface $productTaxonsMapper
-     * @param string $attributeProperty
-     * @param string $taxonsProperty
-     * @param array $excludedAttributes
+     * @param BitbagTaxonRepository $bitbagTaxonRepository
+     * @param string                $taxonsProperty
+     * @param array                 $excludedAttributes
      */
     public function __construct(
-        ProductAttributeValueRepositoryInterface $productAttributeValueRepository,
-        ProductTaxonsMapperInterface $productTaxonsMapper,
-        string $attributeProperty,
+        BitbagTaxonRepository $bitbagTaxonRepository,
         string $taxonsProperty,
         array $excludedAttributes = []
     ) {
-        $this->productAttributeValueRepository = $productAttributeValueRepository;
-        $this->productTaxonsMapper = $productTaxonsMapper;
-        $this->attributeProperty = $attributeProperty;
-        $this->taxonsProperty = $taxonsProperty;
-        $this->excludedAttributes = $excludedAttributes;
+        $this->bitbagTaxonRepository = $bitbagTaxonRepository;
+        $this->taxonsProperty        = $taxonsProperty;
+        $this->excludedAttributes    = $excludedAttributes;
     }
 
     /**
@@ -80,20 +61,15 @@ final class AttributeTaxonsBuilder extends AbstractBuilder
             return;
         }
 
-        $document = $event->getDocument();
-        $productAttributes = $this->productAttributeValueRepository->findBy(['attribute' => $documentAttribute]);
-        $taxons = [];
+        $taxons = $this->bitbagTaxonRepository->getTaxonsByAttributeViaProduct($documentAttribute);
 
-        /** @var ProductAttributeValueInterface $attributeValue */
-        foreach ($productAttributes as $attributeValue) {
-            /** @var ProductInterface $product */
-            $product = $attributeValue->getProduct();
-
-            if ($documentAttribute === $attributeValue->getAttribute() && $product->isEnabled()) {
-                $taxons = $this->productTaxonsMapper->mapToUniqueCodes($product);
-            }
+        $taxonCodes = [];
+        foreach ($taxons as $taxon) {
+            $taxonCodes[] = $taxon->getCode();
         }
 
-        $document->set($this->taxonsProperty, $taxons);
+        $document = $event->getDocument();
+
+        $document->set($this->taxonsProperty, $taxonCodes);
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,3 +20,11 @@ services:
         class: BitBag\SyliusElasticsearchPlugin\EntityRepository\ProductVariantRepository
         arguments:
             - "@sylius.repository.product_variant"
+
+    bitbag.sylius_elasticsearch_plugin.entity_repository.taxon_repository:
+        class: BitBag\SyliusElasticsearchPlugin\EntityRepository\TaxonRepository
+        arguments:
+            - "@sylius.repository.taxon"
+            - "@sylius.repository.product"
+            - "%sylius.model.product_taxon.class%"
+            - "%sylius.model.product_attribute_value.class%"

--- a/src/Resources/config/services/property_builder.yml
+++ b/src/Resources/config/services/property_builder.yml
@@ -78,9 +78,7 @@ services:
     bitbag_sylius_elasticsearch_plugin.property_builder.attribute_taxons:
         class: BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AttributeTaxonsBuilder
         arguments:
-            - "@sylius.repository.product_attribute_value"
-            - "@bitbag_sylius_elasticsearch_plugin.property_builder.mapper.product_taxons"
-            - "%bitbag_es_shop_attribute_property_prefix%"
+            - "@bitbag.sylius_elasticsearch_plugin.entity_repository.taxon_repository"
             - "%bitbag_es_shop_attribute_taxons_property%"
             - "%bitbag_es_excluded_filter_attributes%"
         tags:


### PR DESCRIPTION
Updated attribute taxon builder to not select, basically, whole product attribute value table, into the memory and dying with Out Of Memory error.
Pushed the data grouping and crunching to select taxons that are relevant for current attribute down to the SQL level, returning all taxons in the worst case, which usually is at most a few thousand records, when an attribute is assigned to every single product (or products that combined have all taxons assigned to them).

Fix for #17 

P.S. If you have A LOT of taxons (5 digit numbers) - I'm sorry, but you will just have to bump your available RAM. Or, we will have to rewrite the whole thing to unbuffered queries and/or iterator style processing in batches (basically paging the results).