### PR TITLE
Out Of Memory for for attribute filters

### DIFF
--- a/src/EntityRepository/ProductAttributeRepository.php
+++ b/src/EntityRepository/ProductAttributeRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BitBag\SyliusElasticsearchPlugin\EntityRepository;
+
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductAttributeValueRepository as BaseRepository;
+use Sylius\Component\Attribute\Model\AttributeInterface;
+use Sylius\Component\Product\Model\ProductAttributeValueInterface;
+
+class ProductAttributeRepository implements ProductAttributeValueRepositoryInterface
+{
+
+    /**
+     * @var BaseRepository
+     */
+    protected $repository;
+
+    public function __construct(BaseRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param AttributeInterface $productAttribute
+     *
+     * @return array|ProductAttributeValueInterface[]
+     */
+    public function getUniqueAttributeValues(AttributeInterface $productAttribute): array
+    {
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = $this->repository->createQueryBuilder('o');
+
+        return $queryBuilder
+            ->where('o.attribute = :attribute')
+            ->groupBy('o.'.$productAttribute->getStorageType())
+            ->setParameter(':attribute', $productAttribute)
+            ->getQuery()
+            ->getResult();
+    }
+
+}

--- a/src/EntityRepository/ProductAttributeValueRepositoryInterface.php
+++ b/src/EntityRepository/ProductAttributeValueRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BitBag\SyliusElasticsearchPlugin\EntityRepository;
+
+use Sylius\Component\Attribute\Model\AttributeInterface;
+use Sylius\Component\Product\Model\ProductAttributeValueInterface;
+
+interface ProductAttributeValueRepositoryInterface
+{
+
+    /**
+     * @param AttributeInterface $productAttribute
+     *
+     * @return array|ProductAttributeValueInterface[]
+     */
+    public function getUniqueAttributeValues(AttributeInterface $productAttribute): array;
+}

--- a/src/Form/Type/ProductAttributesFilterType.php
+++ b/src/Form/Type/ProductAttributesFilterType.php
@@ -29,19 +29,28 @@ final class ProductAttributesFilterType extends AbstractFilterType
     /** @var ProductAttributesMapperInterface */
     private $productAttributesMapper;
 
+    /** @var array */
+    protected $excludedAttributes;
+
     public function __construct(
         ProductAttributesContextInterface $productAttributesContext,
         ConcatedNameResolverInterface $attributeNameResolver,
-        ProductAttributesMapperInterface $productAttributesMapper
+        ProductAttributesMapperInterface $productAttributesMapper,
+        array $excludedAttributes
     ) {
         $this->productAttributesContext = $productAttributesContext;
         $this->attributeNameResolver = $attributeNameResolver;
         $this->productAttributesMapper = $productAttributesMapper;
+        $this->excludedAttributes = $excludedAttributes;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $attributes): void
     {
         foreach ($this->productAttributesContext->getAttributes() as $productAttribute) {
+            if (in_array($productAttribute->getCode(), $this->excludedAttributes)) {
+                continue;
+            }
+
             $name = $this->attributeNameResolver->resolvePropertyName($productAttribute->getCode());
             $choices = $this->productAttributesMapper->mapToChoices($productAttribute);
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -22,5 +22,9 @@
             <argument>%sylius.model.product_taxon.class%</argument>
             <argument>%sylius.model.product_attribute_value.class%</argument>
         </service>
+
+        <service id="bitbag.sylius_elasticsearch_plugin.entity_repository.product_attribute_value_repository" class="BitBag\SyliusElasticsearchPlugin\EntityRepository\ProductAttributeRepository">
+            <argument type="service" id="sylius.repository.product_attribute_value" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.context.product_attributes" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.property_name_resolver.attribute" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.form.type.choice_mapper.product_attributes" />
+            <argument>%bitbag_es_excluded_filter_attributes%</argument>
 
             <tag name="form.type" />
         </service>
@@ -40,7 +41,7 @@
         </service>
 
         <service id="bitbag_sylius_elasticsearch_plugin.form.type.choice_mapper.product_attributes" class="BitBag\SyliusElasticsearchPlugin\Form\Type\ChoiceMapper\ProductAttributesMapper">
-            <argument type="service" id="sylius.repository.product_attribute_value" />
+            <argument type="service" id="bitbag.sylius_elasticsearch_plugin.entity_repository.product_attribute_value_repository" />
             <argument type="service" id="sylius.context.locale" />
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.string_formatter" />
         </service>


### PR DESCRIPTION
This PR fixes the Out Of Memory error by pushing unique value selection to SQL level instead of iteration in PHP.

The original issue is that the bigger the database was, the more objects were selected from DB, resulting, in our case, in about 300 000 ProductAttributeValue array of objects created in memory and obviously it was not only slow but hit the memory limit fast.
Also excluded attributes where always rendered too, which didn't help cause we had 400k attributes named "Description" that were unique for each product, resulting in absurd memory requirements and hydration taking ages despite the attribute being in the excluded array.

The fix is not perfect - that GROUP BY is going to be slow when there are a lot of values for a given attribute because there are no indexes. And some attributes can be on each product - we for now dealt with it by putting such attributes into the excluded array. Also, boolean/checkbox attributes right now make no sense for filtering and need further development.

Also, doing a GROUP BY on a json, array or text field is, well, stupid, ludicrous, plain and simple - an issue that needs to be handled.