### PR TITLE
Remove duplicated form in products index page

### DIFF
--- a/src/Resources/views/Shop/Product/Index/_filterForm.html.twig
+++ b/src/Resources/views/Shop/Product/Index/_filterForm.html.twig
@@ -1,14 +1,12 @@
-<form method="get" class="ui loadable form">
-    <div class="item">
-        {{ form_row(form.options) }}
-    </div>
-    <div class="item">
-        {{ form_row(form.attributes) }}
-    </div>
-    <div class="item">
-        {{ form_row(form.price) }}
-    </div>
-    <div class="item">
-        <button type="submit" class="ui primary icon labeled button" style="width: 100%;"><i class="search icon"></i> {{ 'bitbag_sylius_elasticsearch_plugin.ui.filter'|trans }}</button>
-    </div>
-</form>
+<div class="item">
+    {{ form_row(form.options) }}
+</div>
+<div class="item">
+    {{ form_row(form.attributes) }}
+</div>
+<div class="item">
+    {{ form_row(form.price) }}
+</div>
+<div class="item">
+    <button type="submit" class="ui primary icon labeled button" style="width: 100%;"><i class="search icon"></i> {{ 'bitbag_sylius_elasticsearch_plugin.ui.filter'|trans }}</button>
+</div>


### PR DESCRIPTION
The form is already defined here https://github.com/BitBagCommerce/SyliusElasticsearchPlugin/blob/2dea56d8fb693cbc9466bbaaf7de0feb62f63272/src/Resources/views/Shop/Product/index.html.twig#L19

There's no need to define it again in the `_filterForm.html.twig` file.