### PR TITLE
Fix ES search request failing when sorting on empty categories/results

### DIFF
--- a/src/Controller/RequestDataHandler/ShopProductsSortDataHandler.php
+++ b/src/Controller/RequestDataHandler/ShopProductsSortDataHandler.php
@@ -77,7 +77,7 @@ final class ShopProductsSortDataHandler implements SortDataHandlerInterface
             $orderBy = $this->channelPricingNameResolver->resolvePropertyName($channelCode);
         }
 
-        $data['sort'] = [$orderBy => ['order' => strtolower($sort)]];
+        $data['sort'] = [$orderBy => ['order' => strtolower($sort), 'unmapped_type' => 'keyword']];
 
         return $data;
     }


### PR DESCRIPTION
Elasticsearch 6.8.3
Sylius 1.6

When trying to integrate Elasticsearch into Sylius, I can across an interesting problem.
If I navigate to an category with no products in it, Symfony (and ES) will return an error like this:

> An exception has been thrown during the rendering of a template ("No mapping found for [taxon_position_somecategory] in order to sort on [index: bitbag_shop_products_dev] [reason: all shards failed]").

The sorting fails due to there being no mapping associated with a field in the search request.
More info: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-sort.html#_ignoring_unmapped_fields

I added `unmapped_type = keyword` to the sort options. This will make sure it will not fail the search request if the result is empty.