### PR TITLE
Improved index type settings

### DIFF
--- a/src/Resolver/IndexableInterface.php
+++ b/src/Resolver/IndexableInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Peter Ukena <peter.ukena@brille24.de>
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusElasticsearchPlugin\Resolver;
+
+use Sylius\Component\Core\Model\ProductInterface;
+
+interface IndexableInterface
+{
+    /**
+     * In all cases, the callback should return a true or false, with true indicating it will be indexed,
+     * and a false indicating the object should not be indexed, or should be removed from
+     * the index if we are running an update.
+     *
+     * @see https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/doc/types.md#testing-if-an-object-should-be-indexed
+     *
+     * @param ProductInterface $product
+     *
+     * @return bool
+     */
+    public function isProductIndexable(ProductInterface $product): bool;
+}

--- a/src/Resolver/IndexableResolver.php
+++ b/src/Resolver/IndexableResolver.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author Peter Ukena <peter.ukena@brille24.de>
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusElasticsearchPlugin\Resolver;
+
+use Sylius\Component\Core\Model\ProductInterface;
+
+class IndexableResolver implements IndexableInterface
+{
+    /** {@inheritdoc} */
+    public function isProductIndexable(ProductInterface $product): bool
+    {
+        // Check if product is enabled at all.
+        if (!$product->isEnabled()) {
+            return false;
+        }
+
+        /**
+         * We can check things like
+         *   * Stock
+         *   * Channel
+         *   * ...
+         */
+
+        return true;
+    }
+}

--- a/src/Resources/config/indexes/bitbag_shop_products.yml
+++ b/src/Resources/config/indexes/bitbag_shop_products.yml
@@ -16,13 +16,20 @@ fos_elastica:
             index_name: "bitbag_shop_products_%kernel.environment%"
             types:
                 default:
+                    indexable_callback: ['@BitBag\SyliusElasticsearchPlugin\Resolver\IndexableResolver', 'isProductIndexable']
                     properties:
-                        enabled: ~
+                        code:
+                            type: 'string'
+                            analyzer: 'whitespace'
                     persistence:
+                        identifier: 'code'
                         driver: orm
                         model: "%sylius.model.product.class%"
+                        ###> All listeners are disabled. We handle this with a sylius-resource-event listener.
                         listener:
-                            defer: true
+                            insert: false
+                            update: false
+                            delete: false
                             logger: true
                         elastica_to_model_transformer:
                             ignore_missing: true

--- a/src/Resources/config/services/resolver.xml
+++ b/src/Resources/config/services/resolver.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="BitBag\SyliusElasticsearchPlugin\Resolver\IndexableResolver" />
+    </services>
+</container>


### PR DESCRIPTION
* The productCode is now the identifier of the ES document
* The productCode is now a static property of the object with whitespace-analyzer to get rid of the dash-problem
* A service exists to call and ask if a product should be indexed or not.