### PR TITLE
Fixed determination of supported class for refresher

### DIFF
--- a/src/EventListener/ResourceIndexListener.php
+++ b/src/EventListener/ResourceIndexListener.php
@@ -38,7 +38,7 @@ final class ResourceIndexListener
         Assert::isInstanceOf($resource, ResourceInterface::class);
 
         foreach ($this->persistersMap as $objectPersisterId => $modelClass) {
-            if ($modelClass === get_class($resource)) {
+            if ($resource instanceof $modelClass) {
                 $this->resourceRefresher->refresh($resource, $objectPersisterId);
             }
         }


### PR DESCRIPTION
Since I wanted to use the refresh-listener with custom events, I noticed that it compares classnames as strings.

By putting repository-loaded entities in my events, I got proxy classnames in the listener, which were skipped with the check.

Using instance of solves the problem.