### PR TITLE
Added a remove-mode if a resource is not enabled

### DIFF
--- a/src/EventListener/ResourceIndexListener.php
+++ b/src/EventListener/ResourceIndexListener.php
@@ -39,7 +39,12 @@ final class ResourceIndexListener
 
         foreach ($this->persistersMap as $objectPersisterId => $modelClass) {
             if ($resource instanceof $modelClass) {
-                $this->resourceRefresher->refresh($resource, $objectPersisterId);
+                // Respect an enabled-switch on the resource
+                if (method_exists($resource, 'isEnabled') && $resource->isEnabled()) {
+                    $this->resourceRefresher->remove($resource, $objectPersisterId);
+                } else {
+                    $this->resourceRefresher->refresh($resource, $objectPersisterId);
+                }
             }
         }
     }

--- a/src/Refresher/ResourceRefresher.php
+++ b/src/Refresher/ResourceRefresher.php
@@ -35,4 +35,13 @@ final class ResourceRefresher implements ResourceRefresherInterface
 
         $objectPersister->replaceOne($resource);
     }
+
+    public function remove(ResourceInterface $resource, string $objectPersisterId): void
+    {
+        /** @var ObjectPersisterInterface $objectPersister */
+        $objectPersister = $this->container->get($objectPersisterId);
+        Assert::isInstanceOf($objectPersister, ObjectPersisterInterface::class);
+
+        $objectPersister->deleteOne($resource);
+    }
 }

--- a/src/Refresher/ResourceRefresherInterface.php
+++ b/src/Refresher/ResourceRefresherInterface.php
@@ -17,4 +17,6 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 interface ResourceRefresherInterface
 {
     public function refresh(ResourceInterface $resource, string $objectPersisterId): void;
+
+    public function remove(ResourceInterface $resource, string $objectPersisterId): void;
 }


### PR DESCRIPTION
Currently there is no way to get a resource out of the index or to see if its enabled or not. 

As far as I know, neither "enabled" is submitted as a property (its submitted as always true, see [configuration](https://github.com/BitBagCommerce/SyliusElasticsearchPlugin/blob/7138ee6d859b8a26aaf52bdd12c2d2dd022128f3/src/Resources/config/indexes/bitbag_shop_products.yml#L22))

This adds a check on the listener, if the handled resource has an "isEnabled" function and if that results to *false*. In that case, the refresher is used to remove the resource from the ES index.

This way, unavailable resources in Sylius will also be unavailable in ES. *Note:* I built this to remove products from ES, we dont use it to handle taxons and attributes.