### PR TITLE
Add locale to money formatter for ChannelPricingTransformer

### DIFF
--- a/spec/Transformer/Product/ChannelPricingTransformerSpec.php
+++ b/spec/Transformer/Product/ChannelPricingTransformerSpec.php
@@ -21,16 +21,18 @@ use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 
 final class ChannelPricingTransformerSpec extends ObjectBehavior
 {
     function let(
         ChannelContextInterface $channelContext,
+        LocaleContextInterface $localeContext,
         ProductVariantResolverInterface $productVariantResolver,
         MoneyFormatterInterface $moneyFormatter
     ): void {
-        $this->beConstructedWith($channelContext, $productVariantResolver, $moneyFormatter);
+        $this->beConstructedWith($channelContext, $localeContext, $productVariantResolver, $moneyFormatter);
     }
 
     function it_is_a_transformer(): void
@@ -40,6 +42,7 @@ final class ChannelPricingTransformerSpec extends ObjectBehavior
 
     function it_transforms_product_channel_prices_into_formatted_price(
         ChannelContextInterface $channelContext,
+        LocaleContextInterface $localeContext,
         ProductVariantResolverInterface $productVariantResolver,
         MoneyFormatterInterface $moneyFormatter,
         CurrencyInterface $currency,
@@ -51,11 +54,12 @@ final class ChannelPricingTransformerSpec extends ObjectBehavior
         $currency->getCode()->willReturn('USD');
         $channel->getBaseCurrency()->willReturn($currency);
         $channelContext->getChannel()->willReturn($channel);
+        $localeContext->getLocaleCode()->willReturn('en_US');
         $productVariantResolver->getVariant($product)->willReturn($productVariant);
         $channelPricing->getPrice()->willReturn(10);
         $productVariant->getChannelPricingForChannel($channel)->willReturn($channelPricing);
 
-        $moneyFormatter->format(10, 'USD');
+        $moneyFormatter->format(10, 'USD', 'en_US');
 
         $this->transform($product);
     }

--- a/src/Resources/config/services/transformer.xml
+++ b/src/Resources/config/services/transformer.xml
@@ -4,6 +4,7 @@
     <services>
         <service id="BitBag\SyliusElasticsearchPlugin\Transformer\Product\ChannelPricingTransformer">
             <argument type="service" id="sylius.context.channel" />
+            <argument type="service" id="sylius.context.locale" />
             <argument type="service" id="sylius.product_variant_resolver.default" />
             <argument type="service" id="sylius.money_formatter" />
         </service>

--- a/src/Transformer/Product/ChannelPricingTransformer.php
+++ b/src/Transformer/Product/ChannelPricingTransformer.php
@@ -14,6 +14,7 @@ namespace BitBag\SyliusElasticsearchPlugin\Transformer\Product;
 
 use Sylius\Bundle\MoneyBundle\Formatter\MoneyFormatterInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -24,6 +25,9 @@ final class ChannelPricingTransformer implements TransformerInterface
     /** @var ChannelContextInterface */
     private $channelContext;
 
+    /** @var LocaleContextInterface */
+    private $localeContext;
+
     /** @var ProductVariantResolverInterface */
     private $productVariantResolver;
 
@@ -32,10 +36,12 @@ final class ChannelPricingTransformer implements TransformerInterface
 
     public function __construct(
         ChannelContextInterface $channelContext,
+        LocaleContextInterface $localeContext,
         ProductVariantResolverInterface $productVariantResolver,
         MoneyFormatterInterface $moneyFormatter
     ) {
         $this->channelContext = $channelContext;
+        $this->localeContext = $localeContext;
         $this->productVariantResolver = $productVariantResolver;
         $this->moneyFormatter = $moneyFormatter;
     }
@@ -62,6 +68,6 @@ final class ChannelPricingTransformer implements TransformerInterface
             return null;
         }
 
-        return $this->moneyFormatter->format($productVariantPricing->getPrice(), $channelBaseCurrency->getCode());
+        return $this->moneyFormatter->format($productVariantPricing->getPrice(), $channelBaseCurrency->getCode(), $this->localeContext->getLocaleCode());
     }
 }


### PR DESCRIPTION
Adds the current locale to the money converter (used in the ChannelPricingTransfomer).