### PR TITLE
Prevent checkbox facets from breaking the search/filtering

### DIFF
--- a/src/Form/Type/ChoiceMapper/ProductAttributesMapper.php
+++ b/src/Form/Type/ChoiceMapper/ProductAttributesMapper.php
@@ -82,7 +82,7 @@ final class ProductAttributesMapper implements ProductAttributesMapperInterface
                 }
             } else {
                 $choice = is_string($value) ? $this->stringFormatter->formatToLowercaseWithoutSpaces($value) : $value;
-                $choice = is_bool($value) ? var_export($value, true) : $value;
+                $choice = is_bool($value) ? var_export($value, true) : $choice;
                 $choices[$value] = $choice;
             }
         });

--- a/src/Form/Type/ChoiceMapper/ProductAttributesMapper.php
+++ b/src/Form/Type/ChoiceMapper/ProductAttributesMapper.php
@@ -82,6 +82,7 @@ final class ProductAttributesMapper implements ProductAttributesMapperInterface
                 }
             } else {
                 $choice = is_string($value) ? $this->stringFormatter->formatToLowercaseWithoutSpaces($value) : $value;
+                $choice = is_bool($value) ? var_export($value, true) : $value;
                 $choices[$value] = $choice;
             }
         });


### PR DESCRIPTION
When you have a checkbox value in the list of facets, the filtering no longer works because this class converts true and false to a numerical value. But the numerical value does not match elasticsearch's expectation. With this addition to the mapper, this will now work as expected; though the label still shows an ugly label ;)

This will fix https://github.com/BitBagCommerce/SyliusElasticsearchPlugin/issues/113