### PR TITLE
Fix error for select attribute without value

### DIFF
--- a/src/PropertyBuilder/AttributeBuilder.php
+++ b/src/PropertyBuilder/AttributeBuilder.php
@@ -59,7 +59,7 @@ final class AttributeBuilder extends AbstractBuilder
             $index = $this->attributeNameResolver->resolvePropertyName($attributeCode);
             $value = $attributeValue->getValue();
             if ($attribute->getType() === 'select') {
-                $choices = $attribute->getConfiguration()['choices'];
+                $choices = $attribute->getConfiguration()['choices'] ?? [];
                 if (is_array($value)) {
                     foreach ($value as $i => $item) {
                         $value[$i] = $choices[$item][$this->localeContext->getLocaleCode()] ?? $item;


### PR DESCRIPTION
This merge request allows the use of a select attribute without value.

This case is possible it the attribute values are updated programmatically.