### PR TITLE
Fix for searching attributes like '%100_wool'

### DIFF
--- a/spec/PropertyBuilder/OptionTaxonsBuilderSpec.php
+++ b/spec/PropertyBuilder/OptionTaxonsBuilderSpec.php
@@ -32,7 +32,6 @@ final class OptionTaxonsBuilderSpec extends ObjectBehavior
             $productOptionValueRepository,
             $productVariantRepository,
             $productTaxonsMapper,
-            'option',
             'taxons'
         );
     }

--- a/src/QueryBuilder/HasAttributesQueryBuilder.php
+++ b/src/QueryBuilder/HasAttributesQueryBuilder.php
@@ -24,7 +24,7 @@ final class HasAttributesQueryBuilder implements QueryBuilderInterface
 
         foreach ((array) $data['attribute_values'] as $attributeValue) {
             $termQuery = new Term();
-            $termQuery->setTerm($data['attribute'], $attributeValue);
+            $termQuery->setTerm($data['attribute'] . '.keyword', $attributeValue);
             $attributeQuery->addShould($termQuery);
         }
 

--- a/tests/Behat/Service/Populate.php
+++ b/tests/Behat/Service/Populate.php
@@ -19,7 +19,7 @@ use FOS\ElasticaBundle\Index\Resetter;
 use FOS\ElasticaBundle\Persister\PagerPersisterInterface;
 use FOS\ElasticaBundle\Persister\PagerPersisterRegistry;
 use FOS\ElasticaBundle\Provider\PagerProviderRegistry;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class Populate
 {
@@ -75,7 +75,7 @@ final class Populate
 
         foreach ($indexes as $index) {
             $event = new IndexPopulateEvent($index, true, $options);
-            $this->dispatcher->dispatch(IndexPopulateEvent::PRE_INDEX_POPULATE, $event);
+            $this->dispatcher->dispatch($event, IndexPopulateEvent::PRE_INDEX_POPULATE);
 
             if ($event->isReset()) {
                 $this->resetter->resetIndex($index, true);
@@ -86,7 +86,7 @@ final class Populate
                 $this->populateIndexType($index, $type, false, $event->getOptions());
             }
 
-            $this->dispatcher->dispatch(IndexPopulateEvent::POST_INDEX_POPULATE, $event);
+            $this->dispatcher->dispatch($event, IndexPopulateEvent::POST_INDEX_POPULATE);
 
             $this->refreshIndex($index);
         }
@@ -101,7 +101,7 @@ final class Populate
     private function populateIndexType(string $index, string $type, bool $reset, array $options): void
     {
         $event = new TypePopulateEvent($index, $type, $reset, $options);
-        $this->dispatcher->dispatch(TypePopulateEvent::PRE_TYPE_POPULATE, $event);
+        $this->dispatcher->dispatch($event, TypePopulateEvent::PRE_TYPE_POPULATE);
 
         if ($event->isReset()) {
             $this->resetter->resetIndexType($index, $type);
@@ -116,7 +116,7 @@ final class Populate
 
         $this->pagerPersister->insert($pager, $options);
 
-        $this->dispatcher->dispatch(TypePopulateEvent::POST_TYPE_POPULATE, $event);
+        $this->dispatcher->dispatch($event, TypePopulateEvent::POST_TYPE_POPULATE);
 
         $this->refreshIndex($index);
     }


### PR DESCRIPTION
changes
`{"bool":{"should":[{"term":{"attribute_cap_material":{"value":"100%_wool","boost":1}}}]}`
to 

`{"bool":{"should":[{"term":{"attribute_cap_material.keyword":{"value":"100%_wool","boost":1}}}]}`
and this appears to fix the problem