### PR TITLE
Reindex product after order (to update units sold)

### DIFF
--- a/spec/PropertyBuilder/SoldUnitsPropertyBuilderSpec.php
+++ b/spec/PropertyBuilder/SoldUnitsPropertyBuilderSpec.php
@@ -15,9 +15,9 @@ namespace spec\BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\SoldUnitsPropertyBuilder;
+use BitBag\SyliusElasticsearchPlugin\Repository\OrderItemRepositoryInterface;
 use FOS\ElasticaBundle\Event\TransformEvent;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
 
 final class SoldUnitsPropertyBuilderSpec extends ObjectBehavior
 {

--- a/src/EventListener/OrderProductsListener.php
+++ b/src/EventListener/OrderProductsListener.php
@@ -12,13 +12,9 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusElasticsearchPlugin\EventListener;
 
-
 use BitBag\SyliusElasticsearchPlugin\Refresher\ResourceRefresherInterface;
 use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\OrderItem;
-use Sylius\Component\Resource\Model\ResourceInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
-use Webmozart\Assert\Assert;
 
 final class OrderProductsListener
 {
@@ -37,9 +33,8 @@ final class OrderProductsListener
     public function updateOrderProducts(Order $order): void
     {
         /** @var OrderItem $orderItem */
-        foreach($order->getItems() as $orderItem) {
+        foreach ($order->getItems() as $orderItem) {
             $this->resourceRefresher->refresh($orderItem->getProduct(), $this->productPersister);
         }
-
     }
 }

--- a/src/EventListener/OrderProductsListener.php
+++ b/src/EventListener/OrderProductsListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+namespace BitBag\SyliusElasticsearchPlugin\EventListener;
+
+
+use BitBag\SyliusElasticsearchPlugin\Refresher\ResourceRefresherInterface;
+use Sylius\Component\Core\Model\Order;
+use Sylius\Component\Core\Model\OrderItem;
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Webmozart\Assert\Assert;
+
+final class OrderProductsListener
+{
+    /** @var ResourceRefresherInterface */
+    private $resourceRefresher;
+
+    /** @var string */
+    private $productPersister;
+
+    public function __construct(ResourceRefresherInterface $resourceRefresher, string $productPersister)
+    {
+        $this->resourceRefresher = $resourceRefresher;
+        $this->productPersister = $productPersister;
+    }
+
+    public function updateOrderProducts(Order $order): void
+    {
+        /** @var OrderItem $orderItem */
+        foreach($order->getItems() as $orderItem) {
+            $this->resourceRefresher->refresh($orderItem->getProduct(), $this->productPersister);
+        }
+
+    }
+}

--- a/src/EventListener/OrderProductsListener.php
+++ b/src/EventListener/OrderProductsListener.php
@@ -14,7 +14,9 @@ namespace BitBag\SyliusElasticsearchPlugin\EventListener;
 
 use BitBag\SyliusElasticsearchPlugin\Refresher\ResourceRefresherInterface;
 use Sylius\Component\Core\Model\Order;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItem;
+use Sylius\Component\Core\Model\OrderItemInterface;
 
 final class OrderProductsListener
 {
@@ -30,9 +32,9 @@ final class OrderProductsListener
         $this->productPersister = $productPersister;
     }
 
-    public function updateOrderProducts(Order $order): void
+    public function updateOrderProducts(OrderInterface $order): void
     {
-        /** @var OrderItem $orderItem */
+        /** @var OrderItemInterface $orderItem */
         foreach ($order->getItems() as $orderItem) {
             $this->resourceRefresher->refresh($orderItem->getProduct(), $this->productPersister);
         }

--- a/src/PropertyBuilder/SoldUnitsPropertyBuilder.php
+++ b/src/PropertyBuilder/SoldUnitsPropertyBuilder.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
+use BitBag\SyliusElasticsearchPlugin\Repository\OrderItemRepositoryInterface;
 use Elastica\Document;
 use FOS\ElasticaBundle\Event\TransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
 
 final class SoldUnitsPropertyBuilder extends AbstractBuilder
 {
@@ -38,7 +38,7 @@ final class SoldUnitsPropertyBuilder extends AbstractBuilder
                 $soldUnits = 0;
 
                 foreach ($product->getVariants() as $productVariant) {
-                    $soldUnits += count($this->orderItemRepository->findBy(['variant' => $productVariant]));
+                    $soldUnits += $this->orderItemRepository->countByVariant($productVariant);
                 }
 
                 $document->set($this->soldUnitsProperty, $soldUnits);

--- a/src/Repository/OrderItemRepository.php
+++ b/src/Repository/OrderItemRepository.php
@@ -28,10 +28,10 @@ class OrderItemRepository implements OrderItemRepositoryInterface
 
     public function countByVariant(ProductVariantInterface $variant, array $orderStates = []): int
     {
-        if (!$orderStates) {
+        if (empty($orderStates)) {
             $orderStates = [OrderInterface::STATE_CANCELLED, OrderInterface::STATE_CART];
         }
-        
+
         return (int) ($this->baseOrderItemRepository
             ->createQueryBuilder('oi')
             ->select('SUM(oi.quantity)')

--- a/src/Repository/OrderItemRepository.php
+++ b/src/Repository/OrderItemRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusElasticsearchPlugin\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+class OrderItemRepository implements OrderItemRepositoryInterface
+{
+    /** @var OrderItemRepositoryInterface */
+    private $baseOrderItemRepository;
+
+    public function __construct(EntityRepository $baseOrderItemRepository)
+    {
+        $this->baseOrderItemRepository = $baseOrderItemRepository;
+    }
+
+    public function countByVariant(ProductVariantInterface $variant): int
+    {
+        $qb = $this->baseOrderItemRepository->createQueryBuilder('i');
+        $qb->select('SUM(i.quantity)')
+            ->where('i.variant = :variant')
+            ->setParameter('variant', $variant)
+            ;
+
+        return (int) ($qb->getQuery()->getSingleScalarResult());
+    }
+}

--- a/src/Repository/OrderItemRepository.php
+++ b/src/Repository/OrderItemRepository.php
@@ -27,12 +27,11 @@ class OrderItemRepository implements OrderItemRepositoryInterface
 
     public function countByVariant(ProductVariantInterface $variant): int
     {
-        $qb = $this->baseOrderItemRepository->createQueryBuilder('i');
-        $qb->select('SUM(i.quantity)')
-            ->where('i.variant = :variant')
+        return (int) ($this->baseOrderItemRepository
+            ->createQueryBuilder('orderItem')
+            ->select('SUM(orderItem.quantity)')
+            ->where('orderItem.variant = :variant')
             ->setParameter('variant', $variant)
-            ;
-
-        return (int) ($qb->getQuery()->getSingleScalarResult());
+            ->getQuery()->getSingleScalarResult());
     }
 }

--- a/src/Repository/OrderItemRepository.php
+++ b/src/Repository/OrderItemRepository.php
@@ -28,10 +28,11 @@ class OrderItemRepository implements OrderItemRepositoryInterface
     public function countByVariant(ProductVariantInterface $variant): int
     {
         return (int) ($this->baseOrderItemRepository
-            ->createQueryBuilder('orderItem')
-            ->select('SUM(orderItem.quantity)')
-            ->where('orderItem.variant = :variant')
+            ->createQueryBuilder('o')
+            ->select('SUM(o.quantity)')
+            ->where('o.variant = :variant')
             ->setParameter('variant', $variant)
-            ->getQuery()->getSingleScalarResult());
+            ->getQuery()
+            ->getSingleScalarResult());
     }
 }

--- a/src/Repository/OrderItemRepositoryInterface.php
+++ b/src/Repository/OrderItemRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusElasticsearchPlugin\Repository;
+
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+interface OrderItemRepositoryInterface
+{
+    public function countByVariant(ProductVariantInterface $variant): int;
+}

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -3,6 +3,7 @@ imports:
     - { resource: "indexes/bitbag_option_taxons.yml" }
     - { resource: "indexes/bitbag_attribute_taxons.yml" }
     - { resource: "indexes/bitbag_shop_facets.yml" }
+    - { resource: "state_machine/sylius_order.yaml" }
 
 parameters:
     bitbag_es_host: localhost

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -27,6 +27,10 @@
             <argument type="service" id="sylius.repository.product_attribute_value" />
         </service>
 
+        <service id="bitbag.sylius_elasticsearch_plugin.repository.order_item_repository" class="BitBag\SyliusElasticsearchPlugin\Repository\OrderItemRepository">
+            <argument type="service" id="sylius.repository.order_item" />
+        </service>
+
         <service id="bitbag.sylius_elasticsearch_plugin.refresher.resource" class="BitBag\SyliusElasticsearchPlugin\Refresher\ResourceRefresher">
             <argument type="service" id="service_container" />
         </service>

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -16,5 +16,9 @@
             <tag name="kernel.event_listener" event="sylius.product.post_create" method="updateIndex" />
             <tag name="kernel.event_listener" event="sylius.product.post_update" method="updateIndex" />
         </service>
+        <service id="bitbag_sylius_elasticsearch_plugin.event_listener.order_products" class="\BitBag\SyliusElasticsearchPlugin\EventListener\OrderProductsListener" public="true">
+            <argument type="service" id="bitbag.sylius_elasticsearch_plugin.refresher.resource" />
+            <argument type="string">fos_elastica.object_persister.bitbag_shop_product.default</argument>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -16,7 +16,7 @@
             <tag name="kernel.event_listener" event="sylius.product.post_create" method="updateIndex" />
             <tag name="kernel.event_listener" event="sylius.product.post_update" method="updateIndex" />
         </service>
-        <service id="bitbag_sylius_elasticsearch_plugin.event_listener.order_products" class="\BitBag\SyliusElasticsearchPlugin\EventListener\OrderProductsListener" public="true">
+        <service id="bitbag_sylius_elasticsearch_plugin.event_listener.order_products" class="BitBag\SyliusElasticsearchPlugin\EventListener\OrderProductsListener" public="true">
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.refresher.resource" />
             <argument type="string">fos_elastica.object_persister.bitbag_shop_product.default</argument>
         </service>

--- a/src/Resources/config/services/property_builder.xml
+++ b/src/Resources/config/services/property_builder.xml
@@ -42,7 +42,7 @@
         </service>
 
         <service id="bitbag_sylius_elasticsearch_plugin.property_builder.sold_units" class="BitBag\SyliusElasticsearchPlugin\PropertyBuilder\SoldUnitsPropertyBuilder">
-            <argument type="service" id="sylius.repository.order_item" />
+            <argument type="service" id="bitbag.sylius_elasticsearch_plugin.repository.order_item_repository" />
             <argument>%bitbag_es_shop_product_sold_units%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
@@ -56,6 +56,7 @@
             <argument type="service" id="sylius.repository.product_option_value" />
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.repository.product_variant" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.property_builder.mapper.product_taxons" />
+            <argument>%bitbag_es_shop_option_property_prefix%</argument>
             <argument>%bitbag_es_shop_option_taxons_property%</argument>
             <argument>%bitbag_es_excluded_filter_options%</argument>
             <tag name="kernel.event_subscriber" />

--- a/src/Resources/config/services/property_builder.xml
+++ b/src/Resources/config/services/property_builder.xml
@@ -56,7 +56,6 @@
             <argument type="service" id="sylius.repository.product_option_value" />
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.repository.product_variant" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.property_builder.mapper.product_taxons" />
-            <argument>%bitbag_es_shop_option_property_prefix%</argument>
             <argument>%bitbag_es_shop_option_taxons_property%</argument>
             <argument>%bitbag_es_excluded_filter_options%</argument>
             <tag name="kernel.event_subscriber" />

--- a/src/Resources/config/state_machine/sylius_order.yaml
+++ b/src/Resources/config/state_machine/sylius_order.yaml
@@ -1,0 +1,8 @@
+winzou_state_machine:
+    sylius_order:
+        callbacks:
+            after:
+                bitbag_sylius_elasticsearch_plugin_index_order_products:
+                    on: ["create"]
+                    do: ["@bitbag_sylius_elasticsearch_plugin.event_listener.order_products", "updateOrderProducts"]
+                    args: ["object"]


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT


Fixes problem with products index not updated properly to reflects units sold after new order

