### PR TITLE
Changed event to sylius.order.post_complete

### DIFF
--- a/src/EventListener/OrderProductsListener.php
+++ b/src/EventListener/OrderProductsListener.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\EventListener;
 
 use BitBag\SyliusElasticsearchPlugin\Refresher\ResourceRefresherInterface;
-use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItem;
 use Sylius\Component\Core\Model\OrderItemInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Webmozart\Assert\Assert;
 
 final class OrderProductsListener
 {
@@ -32,8 +33,11 @@ final class OrderProductsListener
         $this->productPersister = $productPersister;
     }
 
-    public function updateOrderProducts(OrderInterface $order): void
+    public function updateOrderProducts(GenericEvent $event): void
     {
+        $order = $event->getSubject();
+        Assert::isInstanceOf($order, OrderInterface::class);
+
         /** @var OrderItemInterface $orderItem */
         foreach ($order->getItems() as $orderItem) {
             $this->resourceRefresher->refresh($orderItem->getProduct(), $this->productPersister);

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -3,7 +3,6 @@ imports:
     - { resource: "indexes/bitbag_option_taxons.yml" }
     - { resource: "indexes/bitbag_attribute_taxons.yml" }
     - { resource: "indexes/bitbag_shop_facets.yml" }
-    - { resource: "state_machine/sylius_order.yaml" }
 
 parameters:
     bitbag_es_host: localhost

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -19,6 +19,7 @@
         <service id="bitbag_sylius_elasticsearch_plugin.event_listener.order_products" class="BitBag\SyliusElasticsearchPlugin\EventListener\OrderProductsListener" public="true">
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.refresher.resource" />
             <argument type="string">fos_elastica.object_persister.bitbag_shop_product.default</argument>
+            <tag name="kernel.event_listener" event="sylius.order.post_complete" method="updateOrderProducts" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/state_machine/sylius_order.yaml
+++ b/src/Resources/config/state_machine/sylius_order.yaml
@@ -1,8 +1,0 @@
-winzou_state_machine:
-    sylius_order:
-        callbacks:
-            after:
-                bitbag_sylius_elasticsearch_plugin_index_order_products:
-                    on: ["create"]
-                    do: ["@bitbag_sylius_elasticsearch_plugin.event_listener.order_products", "updateOrderProducts"]
-                    args: ["object"]


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/BitBagCommerce/SyliusElasticsearchPlugin/pull/148
| License         | MIT

moves reindexing products / units sold calculation to post_complete event to avoid problems with getting stale data from DB