### PR TITLE
Adds null checks for entity id

### DIFF
--- a/src/PropertyBuilder/AbstractBuilder.php
+++ b/src/PropertyBuilder/AbstractBuilder.php
@@ -14,6 +14,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use FOS\ElasticaBundle\Event\TransformEvent;
 use Sylius\Component\Resource\Model\ToggleableInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
 
 abstract class AbstractBuilder implements PropertyBuilderInterface
 {
@@ -21,7 +22,10 @@ abstract class AbstractBuilder implements PropertyBuilderInterface
     {
         $model = $event->getObject();
 
-        if (!$model instanceof $supportedModelClass || ($model instanceof ToggleableInterface && !$model->isEnabled())) {
+        if (!$model instanceof $supportedModelClass
+            || ($model instanceof ResourceInterface && $model->getId() === null)
+            || ($model instanceof ToggleableInterface && !$model->isEnabled())
+        ) {
             return;
         }
 

--- a/src/PropertyBuilder/AttributeTaxonsBuilder.php
+++ b/src/PropertyBuilder/AttributeTaxonsBuilder.php
@@ -42,6 +42,7 @@ final class AttributeTaxonsBuilder extends AbstractBuilder
         $documentAttribute = $event->getObject();
 
         if (!$documentAttribute instanceof AttributeInterface
+            || $documentAttribute->getId() === null
             || in_array($documentAttribute->getCode(), $this->excludedAttributes)
         ) {
             return;

--- a/src/PropertyBuilder/OptionTaxonsBuilder.php
+++ b/src/PropertyBuilder/OptionTaxonsBuilder.php
@@ -56,6 +56,7 @@ final class OptionTaxonsBuilder extends AbstractBuilder
         $documentProductOption = $event->getObject();
 
         if (!$documentProductOption instanceof ProductOptionInterface
+            || $documentProductOption->getId() === null
             || in_array($documentProductOption->getCode(), $this->excludedOptions, true)
         ) {
             return;


### PR DESCRIPTION
This fix solves an issue where deleted entities with null ids reach the property builders and in some cases the following error is thrown: `Binding entities to query parameters only allowed for entities that have an identifier.`. This happens, for example, for the `AttributeTaxonsBuilder` because it calls the `getTaxonsByAttributeViaProduct` method on the `taxonRepository`, which uses the attribute as a query parameter.

This scenario happens when `defer: true` is set (like on the `bitbag_attribute_taxons` index) and some external code creates entities (in our case attributes), then deletes them before the code execution ends. This exact scenario happens when using the `synolia/SyliusAkeneoPlugin` plugin to import attributes from Akeneo.