### PR TITLE
Fix resource refresher

### DIFF
--- a/src/Refresher/ResourceRefresher.php
+++ b/src/Refresher/ResourceRefresher.php
@@ -33,6 +33,7 @@ final class ResourceRefresher implements ResourceRefresherInterface
         $objectPersister = $this->container->get($objectPersisterId);
         Assert::isInstanceOf($objectPersister, ObjectPersisterInterface::class);
 
+        $objectPersister->deleteById($resource->getId());
         $objectPersister->replaceOne($resource);
     }
 }


### PR DESCRIPTION
This little change fixes the "resource" relations update.

Removing an attribute from the product in the administration panel did not refresh the data and the ES field was still with the previous value.