### PR TITLE
Cast attribute choice value to string

### DIFF
--- a/src/Form/Type/ChoiceMapper/ProductAttributesMapper.php
+++ b/src/Form/Type/ChoiceMapper/ProductAttributesMapper.php
@@ -71,7 +71,7 @@ final class ProductAttributesMapper implements ProductAttributesMapperInterface
                 }
             } else {
                 $choice = is_string($value) ? $this->stringFormatter->formatToLowercaseWithoutSpaces($value) : $value;
-                $choices[$value] = $choice;
+                $choices[(string)$value] = $choice;
             }
         });
         unset($attributeValues);


### PR DESCRIPTION
If you are using float storage for attribute values and your attribute has values:
```
0.1
0.2
0.7
1.1
1.2
1.7
```

Your filter will only render 0 and 1. Cast to string solves this issue.