### PR TITLE
Add PHP 8 Support

### DIFF
--- a/spec/QueryBuilder/ContainsNameQueryBuilderSpec.php
+++ b/spec/QueryBuilder/ContainsNameQueryBuilderSpec.php
@@ -13,7 +13,7 @@ namespace spec\BitBag\SyliusElasticsearchPlugin\QueryBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use BitBag\SyliusElasticsearchPlugin\QueryBuilder\ContainsNameQueryBuilder;
 use BitBag\SyliusElasticsearchPlugin\QueryBuilder\QueryBuilderInterface;
-use Elastica\Query\Match;
+use Elastica\Query\MatchQuery;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
@@ -48,7 +48,7 @@ final class ContainsNameQueryBuilderSpec extends ObjectBehavior
 
         $productNameNameResolver->resolvePropertyName('en')->willReturn('en');
 
-        $this->buildQuery(['name_property' => 'Book'])->shouldBeAnInstanceOf(Match::class);
+        $this->buildQuery(['name_property' => 'Book'])->shouldBeAnInstanceOf(MatchQuery::class);
     }
 
     function it_builds_returned_null_if_property_is_null(

--- a/src/QueryBuilder/ContainsNameQueryBuilder.php
+++ b/src/QueryBuilder/ContainsNameQueryBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\QueryBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Query\AbstractQuery;
-use Elastica\Query\Match;
+use Elastica\Query\MatchQuery;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
 final class ContainsNameQueryBuilder implements QueryBuilderInterface
@@ -44,7 +44,7 @@ final class ContainsNameQueryBuilder implements QueryBuilderInterface
             return null;
         }
 
-        $nameQuery = new Match();
+        $nameQuery = new MatchQuery();
 
         $nameQuery->setFieldQuery($propertyName, $name);
         $nameQuery->setFieldFuzziness($propertyName, 2);


### PR DESCRIPTION
Match is deprecated since version 6.1.2, use the MatchQuery class instead
Also, `match` is a reversed keyword in PHP 8 and not supported.