### PR TITLE
Fix OptionTaxonsBuilder (option only have taxons from the last product)

### DIFF
--- a/src/PropertyBuilder/OptionTaxonsBuilder.php
+++ b/src/PropertyBuilder/OptionTaxonsBuilder.php
@@ -75,10 +75,10 @@ final class OptionTaxonsBuilder extends AbstractBuilder
             $product = $productVariant->getProduct();
 
             if ($documentProductOption === $option && $product->isEnabled()) {
-                $taxons = $this->productTaxonsMapper->mapToUniqueCodes($product);
+                $taxons = array_merge($taxons, $this->productTaxonsMapper->mapToUniqueCodes($product));
             }
         }
 
-        $document->set($this->taxonsProperty, array_unique($taxons));
+        $document->set($this->taxonsProperty, array_values(array_unique($taxons)));
     }
 }


### PR DESCRIPTION
Hi. 

This PR to correct a regression introduced by commit 48a48ee18d8cf6299e018fb253ad6efad2758dc9

In the OptionTaxonsBuilder, taxons were no longer concatenated, only taxons of the last product of the loop were recorded.

The array_values is there to prevent an error at registration: if the array_unique removes elements from taxons array, array keys are no longer consecutive, which blocks the registration in the ObjectPersister.
