### PR TITLE
bump support PHP 8 & fos elastica 6 (only compatible Elasticsearch 7)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "require": {
         "ext-json": "*",
-        "php": "^7.3 || ^7.4",
+        "php": "^7.4 || ^8.0",
         "sylius/sylius": "~1.8.0 || ~1.9.0 || ~1.10.0",
-        "friendsofsymfony/elastica-bundle": "^5.0",
+        "friendsofsymfony/elastica-bundle": "^6.0",
         "symfony/property-access": "^4.4 || ^5.2"
     },
     "require-dev": {

--- a/spec/PropertyBuilder/AttributeBuilderSpec.php
+++ b/spec/PropertyBuilder/AttributeBuilderSpec.php
@@ -15,7 +15,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AttributeBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
@@ -44,7 +44,7 @@ final class AttributeBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/AttributeTaxonsBuilderSpec.php
+++ b/spec/PropertyBuilder/AttributeTaxonsBuilderSpec.php
@@ -14,7 +14,7 @@ use BitBag\SyliusElasticsearchPlugin\Repository\TaxonRepositoryInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AttributeTaxonsBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class AttributeTaxonsBuilderSpec extends ObjectBehavior
@@ -38,7 +38,7 @@ final class AttributeTaxonsBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/ChannelPricingBuilderSpec.php
+++ b/spec/PropertyBuilder/ChannelPricingBuilderSpec.php
@@ -16,7 +16,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\ChannelPricingBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class ChannelPricingBuilderSpec extends ObjectBehavior
@@ -40,7 +40,7 @@ final class ChannelPricingBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/ChannelsBuilderSpec.php
+++ b/spec/PropertyBuilder/ChannelsBuilderSpec.php
@@ -15,7 +15,7 @@ namespace spec\BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\ChannelsBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class ChannelsBuilderSpec extends ObjectBehavior
@@ -36,7 +36,7 @@ final class ChannelsBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/OptionBuilderSpec.php
+++ b/spec/PropertyBuilder/OptionBuilderSpec.php
@@ -17,7 +17,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\OptionBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class OptionBuilderSpec extends ObjectBehavior
@@ -40,7 +40,7 @@ final class OptionBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/OptionTaxonsBuilderSpec.php
+++ b/spec/PropertyBuilder/OptionTaxonsBuilderSpec.php
@@ -15,7 +15,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\Mapper\ProductTaxonsMapperInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\OptionTaxonsBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
@@ -45,7 +45,7 @@ final class OptionTaxonsBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/ProductCreatedAtPropertyBuilderSpec.php
+++ b/spec/PropertyBuilder/ProductCreatedAtPropertyBuilderSpec.php
@@ -13,7 +13,7 @@ namespace spec\BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\ProductCreatedAtPropertyBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class ProductCreatedAtPropertyBuilderSpec extends ObjectBehavior
@@ -34,7 +34,7 @@ final class ProductCreatedAtPropertyBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/ProductDescriptionBuilderSpec.php
+++ b/spec/PropertyBuilder/ProductDescriptionBuilderSpec.php
@@ -8,7 +8,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\ProductDescriptionBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class ProductDescriptionBuilderSpec extends ObjectBehavior
@@ -29,7 +29,7 @@ final class ProductDescriptionBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/ProductNameBuilderSpec.php
+++ b/spec/PropertyBuilder/ProductNameBuilderSpec.php
@@ -16,7 +16,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\ProductNameBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class ProductNameBuilderSpec extends ObjectBehavior
@@ -37,7 +37,7 @@ final class ProductNameBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/ProductShortDescriptionBuilderSpec.php
+++ b/spec/PropertyBuilder/ProductShortDescriptionBuilderSpec.php
@@ -8,7 +8,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\ProductShortDescriptionBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class ProductShortDescriptionBuilderSpec extends ObjectBehavior
@@ -29,7 +29,7 @@ final class ProductShortDescriptionBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/ProductTaxonsBuilderSpec.php
+++ b/spec/PropertyBuilder/ProductTaxonsBuilderSpec.php
@@ -14,7 +14,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\Mapper\ProductTaxonsMapperInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\ProductTaxonsBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class ProductTaxonsBuilderSpec extends ObjectBehavior
@@ -35,7 +35,7 @@ final class ProductTaxonsBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/PropertyBuilder/SoldUnitsPropertyBuilderSpec.php
+++ b/spec/PropertyBuilder/SoldUnitsPropertyBuilderSpec.php
@@ -16,7 +16,7 @@ use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\AbstractBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\PropertyBuilderInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\SoldUnitsPropertyBuilder;
 use BitBag\SyliusElasticsearchPlugin\Repository\OrderItemRepositoryInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use PhpSpec\ObjectBehavior;
 
 final class SoldUnitsPropertyBuilderSpec extends ObjectBehavior
@@ -37,7 +37,7 @@ final class SoldUnitsPropertyBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(PropertyBuilderInterface::class);
     }
 
-    function it_consumes_event(TransformEvent $event): void
+    function it_consumes_event(PostTransformEvent $event): void
     {
         $this->consumeEvent($event);
     }

--- a/spec/QueryBuilder/ContainsNameQueryBuilderSpec.php
+++ b/spec/QueryBuilder/ContainsNameQueryBuilderSpec.php
@@ -13,7 +13,7 @@ namespace spec\BitBag\SyliusElasticsearchPlugin\QueryBuilder;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use BitBag\SyliusElasticsearchPlugin\QueryBuilder\ContainsNameQueryBuilder;
 use BitBag\SyliusElasticsearchPlugin\QueryBuilder\QueryBuilderInterface;
-use Elastica\Query\Match;
+use Elastica\Query\MatchQuery;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
@@ -48,7 +48,7 @@ final class ContainsNameQueryBuilderSpec extends ObjectBehavior
 
         $productNameNameResolver->resolvePropertyName('en')->willReturn('en');
 
-        $this->buildQuery(['name_property' => 'Book'])->shouldBeAnInstanceOf(Match::class);
+        $this->buildQuery(['name_property' => 'Book'])->shouldBeAnInstanceOf(MatchQuery::class);
     }
 
     function it_builds_returned_null_if_property_is_null(

--- a/spec/QueryBuilder/SearchProductsQueryBuilderSpec.php
+++ b/spec/QueryBuilder/SearchProductsQueryBuilderSpec.php
@@ -31,8 +31,8 @@ final class SearchProductsQueryBuilderSpec extends ObjectBehavior
         $this->isEnabeldQuery = new Term();
         $this->isEnabeldQuery->setTerm('enabled', true);
         $isEnabledQueryBuilder->buildQuery([])->willReturn($this->isEnabeldQuery);
-        $this->hasChannelQuery = new Terms();
-        $this->hasChannelQuery->setTerms('channels', ['web_us']);
+        $this->hasChannelQuery = new Terms('channels');
+        $this->hasChannelQuery->setTerms(['web_us']);
         $hasChannelQueryBuilder->buildQuery([])->willReturn($this->hasChannelQuery);
         $this->beConstructedWith(
             $searchPropertyNameResolverRegistry,

--- a/src/EventListener/OrderProductsListener.php
+++ b/src/EventListener/OrderProductsListener.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\EventListener;
 
 use BitBag\SyliusElasticsearchPlugin\Refresher\ResourceRefresherInterface;
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -26,10 +27,10 @@ final class OrderProductsListener
     /** @var ResourceRefresherInterface */
     private $resourceRefresher;
 
-    /** @var string */
+    /** @var ObjectPersisterInterface */
     private $productPersister;
 
-    public function __construct(ResourceRefresherInterface $resourceRefresher, string $productPersister)
+    public function __construct(ResourceRefresherInterface $resourceRefresher, ObjectPersisterInterface $productPersister)
     {
         $this->resourceRefresher = $resourceRefresher;
         $this->productPersister = $productPersister;

--- a/src/EventListener/ProductTaxonIndexListener.php
+++ b/src/EventListener/ProductTaxonIndexListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\EventListener;
 
 use BitBag\SyliusElasticsearchPlugin\Refresher\ResourceRefresherInterface;
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use Sylius\Component\Core\Model\ProductTaxonInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -22,17 +23,17 @@ final class ProductTaxonIndexListener
     /** @var ResourceRefresherInterface */
     private $resourceRefresher;
 
-    /** @var string */
-    private $objectPersisterId;
+    /** @var ObjectPersisterInterface */
+    private $objectPersister;
 
-    public function __construct(ResourceRefresherInterface $resourceRefresher, string $objectPersisterId)
+    public function __construct(ResourceRefresherInterface $resourceRefresher, ObjectPersisterInterface $objectPersister)
     {
         $this->resourceRefresher = $resourceRefresher;
-        $this->objectPersisterId = $objectPersisterId;
+        $this->objectPersister = $objectPersister;
     }
 
     public function updateIndex(ProductTaxonInterface $productTaxon): void
     {
-        $this->resourceRefresher->refresh($productTaxon->getProduct(), $this->objectPersisterId);
+        $this->resourceRefresher->refresh($productTaxon->getProduct(), $this->objectPersister);
     }
 }

--- a/src/PropertyBuilder/AbstractBuilder.php
+++ b/src/PropertyBuilder/AbstractBuilder.php
@@ -9,12 +9,12 @@
 declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Resource\Model\ToggleableInterface;
 
 abstract class AbstractBuilder implements PropertyBuilderInterface
 {
-    public function buildProperty(TransformEvent $event, string $supportedModelClass, callable $callback): void
+    public function buildProperty(PostTransformEvent $event, string $supportedModelClass, callable $callback): void
     {
         $model = $event->getObject();
 
@@ -30,7 +30,7 @@ abstract class AbstractBuilder implements PropertyBuilderInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            TransformEvent::POST_TRANSFORM => 'consumeEvent',
+            PostTransformEvent::class => 'consumeEvent',
         ];
     }
 }

--- a/src/PropertyBuilder/AttributeBuilder.php
+++ b/src/PropertyBuilder/AttributeBuilder.php
@@ -12,7 +12,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 use BitBag\SyliusElasticsearchPlugin\Formatter\StringFormatterInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeTranslation;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -33,7 +33,7 @@ final class AttributeBuilder extends AbstractBuilder
         $this->stringFormatter = $stringFormatter;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/AttributeTaxonsBuilder.php
+++ b/src/PropertyBuilder/AttributeTaxonsBuilder.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\Repository\TaxonRepositoryInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Attribute\Model\AttributeInterface;
 
 final class AttributeTaxonsBuilder extends AbstractBuilder
@@ -34,7 +34,7 @@ final class AttributeTaxonsBuilder extends AbstractBuilder
         $this->excludedAttributes = $excludedAttributes;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $documentAttribute = $event->getObject();
 

--- a/src/PropertyBuilder/ChannelPricingBuilder.php
+++ b/src/PropertyBuilder/ChannelPricingBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
@@ -25,7 +25,7 @@ final class ChannelPricingBuilder extends AbstractBuilder
         $this->channelPricingNameResolver = $channelPricingNameResolver;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/ChannelsBuilder.php
+++ b/src/PropertyBuilder/ChannelsBuilder.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 
 final class ChannelsBuilder extends AbstractBuilder
@@ -23,7 +23,7 @@ final class ChannelsBuilder extends AbstractBuilder
         $this->channelsProperty = $channelsProperty;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/OptionBuilder.php
+++ b/src/PropertyBuilder/OptionBuilder.php
@@ -12,7 +12,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 use BitBag\SyliusElasticsearchPlugin\Formatter\StringFormatterInterface;
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 
 final class OptionBuilder extends AbstractBuilder
@@ -29,7 +29,7 @@ final class OptionBuilder extends AbstractBuilder
         $this->stringFormatter = $stringFormatter;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/OptionTaxonsBuilder.php
+++ b/src/PropertyBuilder/OptionTaxonsBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\Mapper\ProductTaxonsMapperInterface;
 use BitBag\SyliusElasticsearchPlugin\Repository\ProductVariantRepositoryInterface;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductOptionInterface;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
@@ -48,7 +48,7 @@ final class OptionTaxonsBuilder extends AbstractBuilder
         $this->excludedOptions = $excludedOptions;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $documentProductOption = $event->getObject();
 

--- a/src/PropertyBuilder/ProductCodeBuilder.php
+++ b/src/PropertyBuilder/ProductCodeBuilder.php
@@ -10,14 +10,14 @@ declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 
 final class ProductCodeBuilder extends AbstractBuilder
 {
     public const PROPERTY_NAME = 'code';
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/ProductCreatedAtPropertyBuilder.php
+++ b/src/PropertyBuilder/ProductCreatedAtPropertyBuilder.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 
 final class ProductCreatedAtPropertyBuilder extends AbstractBuilder
@@ -23,7 +23,7 @@ final class ProductCreatedAtPropertyBuilder extends AbstractBuilder
         $this->createdAtProperty = $createdAtProperty;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/ProductDescriptionBuilder.php
+++ b/src/PropertyBuilder/ProductDescriptionBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductTranslationInterface;
 
@@ -25,7 +25,7 @@ final class ProductDescriptionBuilder extends AbstractBuilder
         $this->productDescriptionNameResolver = $productDescriptionNameResolver;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/ProductNameBuilder.php
+++ b/src/PropertyBuilder/ProductNameBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductTranslationInterface;
 
@@ -25,7 +25,7 @@ final class ProductNameBuilder extends AbstractBuilder
         $this->productNameNameResolver = $productNameNameResolver;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/ProductShortDescriptionBuilder.php
+++ b/src/PropertyBuilder/ProductShortDescriptionBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductTranslationInterface;
 
@@ -25,7 +25,7 @@ final class ProductShortDescriptionBuilder extends AbstractBuilder
         $this->productShortDescriptionNameResolver = $productShortDescriptionNameResolver;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/ProductTaxonPositionPropertyBuilder.php
+++ b/src/PropertyBuilder/ProductTaxonPositionPropertyBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 
 final class ProductTaxonPositionPropertyBuilder extends AbstractBuilder
@@ -24,7 +24,7 @@ final class ProductTaxonPositionPropertyBuilder extends AbstractBuilder
         $this->taxonPositionNameResolver = $taxonPositionNameResolver;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/ProductTaxonsBuilder.php
+++ b/src/PropertyBuilder/ProductTaxonsBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyBuilder\Mapper\ProductTaxonsMapperInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 
 final class ProductTaxonsBuilder extends AbstractBuilder
@@ -28,7 +28,7 @@ final class ProductTaxonsBuilder extends AbstractBuilder
         $this->taxonsProperty = $taxonsProperty;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/PropertyBuilder/PropertyBuilderInterface.php
+++ b/src/PropertyBuilder/PropertyBuilderInterface.php
@@ -9,12 +9,12 @@
 declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 interface PropertyBuilderInterface extends EventSubscriberInterface
 {
-    public function consumeEvent(TransformEvent $event): void;
+    public function consumeEvent(PostTransformEvent $event): void;
 
-    public function buildProperty(TransformEvent $event, string $class, callable $callback): void;
+    public function buildProperty(PostTransformEvent $event, string $class, callable $callback): void;
 }

--- a/src/PropertyBuilder/SoldUnitsPropertyBuilder.php
+++ b/src/PropertyBuilder/SoldUnitsPropertyBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\PropertyBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\Repository\OrderItemRepositoryInterface;
 use Elastica\Document;
-use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\Event\PostTransformEvent;
 use Sylius\Component\Core\Model\ProductInterface;
 
 final class SoldUnitsPropertyBuilder extends AbstractBuilder
@@ -28,7 +28,7 @@ final class SoldUnitsPropertyBuilder extends AbstractBuilder
         $this->soldUnitsProperty = $soldUnitsProperty;
     }
 
-    public function consumeEvent(TransformEvent $event): void
+    public function consumeEvent(PostTransformEvent $event): void
     {
         $this->buildProperty($event, ProductInterface::class,
             function (ProductInterface $product, Document $document): void {

--- a/src/QueryBuilder/ContainsNameQueryBuilder.php
+++ b/src/QueryBuilder/ContainsNameQueryBuilder.php
@@ -11,7 +11,7 @@ namespace BitBag\SyliusElasticsearchPlugin\QueryBuilder;
 
 use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
 use Elastica\Query\AbstractQuery;
-use Elastica\Query\Match;
+use Elastica\Query\MatchQuery;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
 final class ContainsNameQueryBuilder implements QueryBuilderInterface
@@ -44,7 +44,7 @@ final class ContainsNameQueryBuilder implements QueryBuilderInterface
             return null;
         }
 
-        $nameQuery = new Match();
+        $nameQuery = new MatchQuery();
 
         $nameQuery->setFieldQuery($propertyName, $name);
         $nameQuery->setFieldFuzziness($propertyName, 2);

--- a/src/QueryBuilder/HasChannelQueryBuilder.php
+++ b/src/QueryBuilder/HasChannelQueryBuilder.php
@@ -29,8 +29,8 @@ final class HasChannelQueryBuilder implements QueryBuilderInterface
 
     public function buildQuery(array $data): ?AbstractQuery
     {
-        $channelQuery = new Terms();
-        $channelQuery->setTerms($this->channelsProperty, [strtolower($this->channelContext->getChannel()->getCode())]);
+        $channelQuery = new Terms($this->channelsProperty);
+        $channelQuery->setTerms([strtolower($this->channelContext->getChannel()->getCode())]);
 
         return $channelQuery;
     }

--- a/src/QueryBuilder/HasTaxonQueryBuilder.php
+++ b/src/QueryBuilder/HasTaxonQueryBuilder.php
@@ -28,8 +28,8 @@ final class HasTaxonQueryBuilder implements QueryBuilderInterface
             return null;
         }
 
-        $taxonQuery = new Terms();
-        $taxonQuery->setTerms($this->taxonsProperty, [$taxonCode]);
+        $taxonQuery = new Terms($this->taxonsProperty);
+        $taxonQuery->setTerms([$taxonCode]);
 
         return $taxonQuery;
     }

--- a/src/Refresher/ResourceRefresher.php
+++ b/src/Refresher/ResourceRefresher.php
@@ -26,12 +26,8 @@ final class ResourceRefresher implements ResourceRefresherInterface
         $this->container = $container;
     }
 
-    public function refresh(ResourceInterface $resource, string $objectPersisterId): void
+    public function refresh(ResourceInterface $resource, ObjectPersisterInterface $objectPersister): void
     {
-        /** @var ObjectPersisterInterface $objectPersister */
-        $objectPersister = $this->container->get($objectPersisterId);
-        Assert::isInstanceOf($objectPersister, ObjectPersisterInterface::class);
-
         $objectPersister->deleteById($resource->getId());
         $objectPersister->replaceOne($resource);
     }

--- a/src/Refresher/ResourceRefresherInterface.php
+++ b/src/Refresher/ResourceRefresherInterface.php
@@ -9,9 +9,10 @@
 declare(strict_types=1);
 namespace BitBag\SyliusElasticsearchPlugin\Refresher;
 
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 
 interface ResourceRefresherInterface
 {
-    public function refresh(ResourceInterface $resource, string $objectPersisterId): void;
+    public function refresh(ResourceInterface $resource, ObjectPersisterInterface $objectPersisterId): void;
 }

--- a/src/Resources/config/indexes/bitbag_attribute_taxons.yml
+++ b/src/Resources/config/indexes/bitbag_attribute_taxons.yml
@@ -5,16 +5,14 @@ fos_elastica:
     indexes:
         bitbag_attribute_taxons:
             index_name: "bitbag_attribute_taxons_%kernel.environment%"
-            types:
-                default:
-                    properties:
-                        attribute_code:
-                            property_path: code
-                    persistence:
-                        driver: orm
-                        model: "%sylius.model.product_attribute.class%"
-                        listener:
-                            defer: true
-                            logger: true
-                        elastica_to_model_transformer:
-                            ignore_missing: true
+            properties:
+                attribute_code:
+                    property_path: code
+            persistence:
+                driver: orm
+                model: "%sylius.model.product_attribute.class%"
+                listener:
+                    defer: true
+                    logger: true
+                elastica_to_model_transformer:
+                    ignore_missing: true

--- a/src/Resources/config/indexes/bitbag_option_taxons.yml
+++ b/src/Resources/config/indexes/bitbag_option_taxons.yml
@@ -5,16 +5,14 @@ fos_elastica:
     indexes:
         bitbag_option_taxons:
             index_name: "bitbag_option_taxons_%kernel.environment%"
-            types:
-                default:
-                    properties:
-                        option_code:
-                            property_path: code
-                    persistence:
-                        driver: orm
-                        model: "%sylius.model.product_option.class%"
-                        listener:
-                            defer: true
-                            logger: true
-                        elastica_to_model_transformer:
-                            ignore_missing: true
+            properties:
+                option_code:
+                    property_path: code
+            persistence:
+                driver: orm
+                model: "%sylius.model.product_option.class%"
+                listener:
+                    defer: true
+                    logger: true
+                elastica_to_model_transformer:
+                    ignore_missing: true

--- a/src/Resources/config/indexes/bitbag_shop_products.yml
+++ b/src/Resources/config/indexes/bitbag_shop_products.yml
@@ -16,15 +16,13 @@ fos_elastica:
     indexes:
         bitbag_shop_product:
             index_name: "bitbag_shop_products_%kernel.environment%"
-            types:
-                default:
-                    properties:
-                        enabled: ~
-                    persistence:
-                        driver: orm
-                        model: "%sylius.model.product.class%"
-                        listener:
-                            defer: true
-                            logger: true
-                        elastica_to_model_transformer:
-                            ignore_missing: true
+            properties:
+                enabled: ~
+            persistence:
+                driver: orm
+                model: "%sylius.model.product.class%"
+                listener:
+                    defer: true
+                    logger: true
+                elastica_to_model_transformer:
+                    ignore_missing: true

--- a/src/Resources/config/services/controller/shop.xml
+++ b/src/Resources/config/services/controller/shop.xml
@@ -14,7 +14,7 @@
 
         <service id="bitbag_sylius_elasticsearch_plugin.controller.action.shop.search" class="BitBag\SyliusElasticsearchPlugin\Controller\Action\Shop\SearchAction">
             <argument type="service" id="twig" />
-            <argument type="service" id="fos_elastica.finder.bitbag_shop_product.default" />
+            <argument type="service" id="fos_elastica.finder.bitbag_shop_product" />
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.block_event_listener.search_form" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.facet.registry" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.query_builder.search_products" />

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -7,16 +7,16 @@
             <argument type="collection">
                 <argument type="collection">
                     <argument key="model">%sylius.model.product_attribute.class%</argument>
-                    <argument key="serviceId">fos_elastica.object_persister.bitbag_attribute_taxons.default</argument>
+                    <argument key="serviceId">fos_elastica.object_persister.bitbag_attribute_taxons</argument>
                 </argument>
                 <argument type="collection">
                     <argument key="model">%sylius.model.product_option.class%</argument>
-                    <argument key="serviceId">fos_elastica.object_persister.bitbag_option_taxons.default</argument>
+                    <argument key="serviceId">fos_elastica.object_persister.bitbag_option_taxons</argument>
                 </argument>
                 <argument type="collection">
                     <argument key="getParentMethod">getProduct</argument>
                     <argument key="model">%sylius.model.product.class%</argument>
-                    <argument key="serviceId">fos_elastica.object_persister.bitbag_shop_product.default</argument>
+                    <argument key="serviceId">fos_elastica.object_persister.bitbag_shop_product</argument>
                 </argument>
             </argument>
             <tag name="kernel.event_listener" event="sylius.product_attribute.post_create" method="updateIndex" />
@@ -30,12 +30,12 @@
         </service>
         <service id="bitbag_sylius_elasticsearch_plugin.event_listener.product_taxon_index" class="BitBag\SyliusElasticsearchPlugin\EventListener\ProductTaxonIndexListener">
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.refresher.resource" />
-            <argument>fos_elastica.object_persister.bitbag_shop_product.default</argument>
+            <argument>fos_elastica.object_persister.bitbag_shop_product</argument>
             <tag name="doctrine.orm.entity_listener" event="postUpdate" method="updateIndex" entity="%sylius.model.product_taxon.class%" />
         </service>
         <service id="bitbag_sylius_elasticsearch_plugin.event_listener.order_products" class="BitBag\SyliusElasticsearchPlugin\EventListener\OrderProductsListener" public="true">
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.refresher.resource" />
-            <argument type="string">fos_elastica.object_persister.bitbag_shop_product.default</argument>
+            <argument type="string">fos_elastica.object_persister.bitbag_shop_product</argument>
             <tag name="kernel.event_listener" event="sylius.order.post_complete" method="updateOrderProducts" />
         </service>
     </services>

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -7,16 +7,16 @@
             <argument type="collection">
                 <argument type="collection">
                     <argument key="model">%sylius.model.product_attribute.class%</argument>
-                    <argument key="serviceId">fos_elastica.object_persister.bitbag_attribute_taxons</argument>
+                    <argument key="serviceId" type="service" id="fos_elastica.object_persister.bitbag_attribute_taxons" />
                 </argument>
                 <argument type="collection">
                     <argument key="model">%sylius.model.product_option.class%</argument>
-                    <argument key="serviceId">fos_elastica.object_persister.bitbag_option_taxons</argument>
+                    <argument key="serviceId" type="service" id="fos_elastica.object_persister.bitbag_option_taxons" />
                 </argument>
                 <argument type="collection">
                     <argument key="getParentMethod">getProduct</argument>
                     <argument key="model">%sylius.model.product.class%</argument>
-                    <argument key="serviceId">fos_elastica.object_persister.bitbag_shop_product</argument>
+                    <argument key="serviceId" type="service" id="fos_elastica.object_persister.bitbag_shop_product" />
                 </argument>
             </argument>
             <tag name="kernel.event_listener" event="sylius.product_attribute.post_create" method="updateIndex" />
@@ -30,12 +30,12 @@
         </service>
         <service id="bitbag_sylius_elasticsearch_plugin.event_listener.product_taxon_index" class="BitBag\SyliusElasticsearchPlugin\EventListener\ProductTaxonIndexListener">
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.refresher.resource" />
-            <argument>fos_elastica.object_persister.bitbag_shop_product</argument>
+            <argument type="service" id="fos_elastica.object_persister.bitbag_shop_product" />
             <tag name="doctrine.orm.entity_listener" event="postUpdate" method="updateIndex" entity="%sylius.model.product_taxon.class%" />
         </service>
         <service id="bitbag_sylius_elasticsearch_plugin.event_listener.order_products" class="BitBag\SyliusElasticsearchPlugin\EventListener\OrderProductsListener" public="true">
             <argument type="service" id="bitbag.sylius_elasticsearch_plugin.refresher.resource" />
-            <argument type="string">fos_elastica.object_persister.bitbag_shop_product</argument>
+            <argument type="service" id="fos_elastica.object_persister.bitbag_shop_product" />
             <tag name="kernel.event_listener" event="sylius.order.post_complete" method="updateOrderProducts" />
         </service>
     </services>

--- a/src/Resources/config/services/finder.xml
+++ b/src/Resources/config/services/finder.xml
@@ -4,22 +4,22 @@
     <services>
         <service id="bitbag_sylius_elasticsearch_plugin.finder.named_products" class="BitBag\SyliusElasticsearchPlugin\Finder\NamedProductsFinder">
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.query_builder.products_by_partial_name" />
-            <argument type="service" id="fos_elastica.finder.bitbag_shop_product.default" />
+            <argument type="service" id="fos_elastica.finder.bitbag_shop_product" />
         </service>
 
         <service id="bitbag_sylius_elasticsearch_plugin.finder.shop_products" class="BitBag\SyliusElasticsearchPlugin\Finder\ShopProductsFinder">
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.query_builder.shop_products" />
-            <argument type="service" id="fos_elastica.finder.bitbag_shop_product.default" />
+            <argument type="service" id="fos_elastica.finder.bitbag_shop_product" />
         </service>
 
         <service id="bitbag_sylius_elasticsearch_plugin.finder.product_options" class="BitBag\SyliusElasticsearchPlugin\Finder\ProductOptionsFinder">
-            <argument type="service" id="fos_elastica.finder.bitbag_option_taxons.default" />
+            <argument type="service" id="fos_elastica.finder.bitbag_option_taxons" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.query_builder.product_options_by_taxon" />
             <argument>%bitbag_es_shop_option_taxons_property%</argument>
         </service>
 
         <service id="bitbag_sylius_elasticsearch_plugin.finder.product_attributes" class="BitBag\SyliusElasticsearchPlugin\Finder\ProductAttributesFinder">
-            <argument type="service" id="fos_elastica.finder.bitbag_attribute_taxons.default" />
+            <argument type="service" id="fos_elastica.finder.bitbag_attribute_taxons" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.query_builder.product_attributes_by_taxon" />
             <argument>%bitbag_es_shop_attribute_taxons_property%</argument>
         </service>

--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -43,7 +43,7 @@
         </service>
 
         <service id="bitbag_sylius_elasticsearch_plugin.form.type.search" class="BitBag\SyliusElasticsearchPlugin\Form\Type\SearchType">
-            <argument type="service" id="fos_elastica.finder.bitbag_shop_product.default" />
+            <argument type="service" id="fos_elastica.finder.bitbag_shop_product" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.facet.registry" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.query_builder.search_products" />
             <tag name="form.type" />


### PR DESCRIPTION
fix #185 

BC breaks: drop support PHP 7.3, fos elastica 6 needs elasticsearch 7.