### PR TITLE
Move `bitbag/coding-standard` to `require-dev`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "sylius/sylius": "~1.8.0 || ~1.9.0 || ~1.10.0",
         "friendsofsymfony/elastica-bundle": "^6.0",
         "symfony/property-access": "^4.4 || ^5.2",
-        "bitbag/coding-standard": "^1.0",
         "symfony/orm-pack": "^2.1",
         "symfony/webpack-encore-bundle": "^1.13"
     },
@@ -41,7 +40,8 @@
         "symfony/dotenv": "^4.4 || ^5.2",
         "symfony/intl": "^4.4 || ^5.2",
         "symfony/web-profiler-bundle": "^4.4 || ^5.2",
-        "vimeo/psalm": "4.7.1"
+        "vimeo/psalm": "4.7.1",
+        "bitbag/coding-standard": "^1.0"
     },
     "conflict": {
         "symfony/form": "4.4.11 || 4.4.12"


### PR DESCRIPTION
I think that this package (`bitbag/coding-standard`) is only for development purposes, it is not a production dependency. This might cause some problems. For example, for us, this causes a big problem, because we use another version of, e.g. PHPStan, which has a fixed version in `bitbag/coding-standard`.