### PR TITLE
Fix PHP 8.1 Iterator interface deprecation notice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
     tests:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
 
         name: "Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
 

--- a/src/Model/SearchFacets.php
+++ b/src/Model/SearchFacets.php
@@ -40,7 +40,7 @@ final class SearchFacets implements Iterator
     /**
      * @inheritdoc
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->selectedBuckets);
     }
@@ -48,15 +48,15 @@ final class SearchFacets implements Iterator
     /**
      * @inheritdoc
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->selectedBuckets);
+        next($this->selectedBuckets);
     }
 
     /**
      * @inheritdoc
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->selectedBuckets);
     }
@@ -74,7 +74,7 @@ final class SearchFacets implements Iterator
     /**
      * @inheritdoc
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->selectedBuckets);
     }


### PR DESCRIPTION
Fixes error in PHP 8.1

```PHP Fatal error:  During inheritance of Iterator: Uncaught Behat\Testwork\Call\Exception\CallErrorException: 8192: Return type of BitBag\SyliusElasticsearchPlugin\Model\SearchFacets::next() should be compatible with Iterator::next(): void```