### PR TITLE
Optimize shop products query builder by making enabled column to be q…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "behat/behat": "^3.7",
-        "behat/mink-selenium2-driver": "^1.4",
+        "behat/mink-selenium2-driver": "~1.6.0",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",
@@ -48,8 +48,7 @@
         "twig/extra-bundle": "^3.4"
     },
     "conflict": {
-        "symfony/form": "4.4.11 || 4.4.12",
-        "doctrine/orm": ">=2.15.2"
+        "symfony/form": "4.4.11 || 4.4.12"
     },
     "autoload": {
         "psr-4": {

--- a/src/QueryBuilder/ShopProductsQueryBuilder.php
+++ b/src/QueryBuilder/ShopProductsQueryBuilder.php
@@ -61,7 +61,7 @@ final class ShopProductsQueryBuilder implements QueryBuilderInterface
     {
         $boolQuery = new BoolQuery();
 
-        $boolQuery->addMust($this->isEnabledQueryBuilder->buildQuery($data));
+        $boolQuery->addFilter($this->isEnabledQueryBuilder->buildQuery($data));
         $boolQuery->addMust($this->hasChannelQueryBuilder->buildQuery($data));
 
         $nameQuery = $this->containsNameQueryBuilder->buildQuery($data);


### PR DESCRIPTION
The must option in elastic should be using in queries where we care about the score. If you want to query columns like published/unpublished or something similar the score is redundant and you can use the filter instead.

The filter clause is often more performant because Elasticsearch can cache the results and optimize the execution.

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html