### PR TITLE
Fix FacetsResolver with no buckets

### DIFF
--- a/src/Api/Resolver/FacetsResolver.php
+++ b/src/Api/Resolver/FacetsResolver.php
@@ -48,7 +48,7 @@ final class FacetsResolver implements FacetsResolverInterface
         }
 
         return array_filter($adapter->getAggregations(), function ($facet) {
-            return [] !== $facet['buckets'] ?? [];
+            return [] !== ($facet['buckets'] ?? []);
         });
     }
 }


### PR DESCRIPTION
This fixes the following issue:
```
Warning: Undefined array key \u0022buckets\u0022 in \/srv\/sylius\/vendor\/bitbag\/elasticsearch-plugin\/src\/Api\/Resolver\/FacetsResolver.php line 51
```