### PR TITLE
Fix channel filter by switching to keyword field in ES query

### DIFF
--- a/features/shop/searching_products_by_a_partial_name.feature
+++ b/features/shop/searching_products_by_a_partial_name.feature
@@ -5,7 +5,7 @@ Feature: Filtering products
     I want to be able to filter products by specific criteria
 
     Background:
-        Given the store operates on a channel named "Web-US" in "USD" currency
+        Given the store operates on a single channel in "United States"
         And the store classifies its products as "Shirts"
         And there is a product named "Loose white designer T-Shirt" in the store
         And there is a product named "Everyday white basic T-Shirt" in the store

--- a/features/shop/site_wide_searching_products.feature
+++ b/features/shop/site_wide_searching_products.feature
@@ -5,7 +5,7 @@ Feature: Site-wide products search
   I want to be able to search products across the entire catalog
 
   Background:
-    Given the store operates on a channel named "Web-US" in "USD" currency
+    Given the store operates on a single channel in "United States"
     And the store classifies its products as "Cars"
     And the store classifies its products as "Motorbikes"
     And the store has a select product attribute "Car Type" with values "Cabrio" and "SUV"

--- a/features/shop/site_wide_searching_products_113.feature
+++ b/features/shop/site_wide_searching_products_113.feature
@@ -5,7 +5,7 @@ Feature: Site-wide products search
   I want to be able to search products across the entire catalog
 
   Background:
-    Given the store operates on a channel named "Web-US" in "USD" currency
+    Given the store operates on a single channel in "United States"
     And the store classifies its products as "Cars"
     And the store classifies its products as "Motorbikes"
     And the store has a select product attribute "Car Type" with values "Cabrio" and "SUV"

--- a/src/QueryBuilder/HasChannelQueryBuilder.php
+++ b/src/QueryBuilder/HasChannelQueryBuilder.php
@@ -26,10 +26,10 @@ final class HasChannelQueryBuilder implements QueryBuilderInterface
 
     public function buildQuery(array $data): ?AbstractQuery
     {
-        $channelQuery = new Terms($this->channelsProperty);
+        $channelQuery = new Terms(sprintf('%s.keyword', $this->channelsProperty));
         /** @var string $channelCode */
         $channelCode = $this->channelContext->getChannel()->getCode();
-        $channelQuery->setTerms([strtolower($channelCode)]);
+        $channelQuery->setTerms([$channelCode]);
 
         return $channelQuery;
     }


### PR DESCRIPTION
The `channels` field in the Elasticsearch index is of type `text`, which means it is analyzed and tokenized (e.g. `WEB-US` becomes `web` and `us`). This caused issues when performing exact match queries using the `Terms` query, especially when channel codes included special characters like hyphens (`-`), as they were split into separate tokens.

To resolve this, the query was updated to use the `.keyword` subfield (`channels.keyword`), which is of type `keyword` and stores the original, unanalyzed value. This ensures that `Terms` queries match the full string exactly as stored in the index.

Additionally, the `strtolower` call was removed, since the `keyword` field is case-sensitive and values should match the exact casing as indexed.