### PR TITLE
Support non translatable attributes

### DIFF
--- a/features/shop/site_wide_searching_products.feature
+++ b/features/shop/site_wide_searching_products.feature
@@ -10,10 +10,12 @@ Feature: Site-wide products search
     And the store classifies its products as "Motorbikes"
     And the store has a select product attribute "Car Type" with values "Cabrio" and "SUV"
     And the store has a select product attribute "Motorbike Type" with values "Enduro" and "Naked"
+    And the store has a non-translatable select product attribute "Wheel size" with value "18"
     And there is a product named "BMW Z4" in the store
     And this product's price is "$42,670.00"
     And this product has select attribute "Car Type" with value "Cabrio"
     And this product has a text attribute "Color" with value "Red"
+    And this product has a select attribute "Wheel size" with value "18"
     And this product has option "Supply" with values "Gasoline" and "Diesel"
     And this product is available in "Gasoline" supply priced at "$42,670.00"
     And this product is available in "Diesel" supply priced at "$45,670.00"
@@ -147,5 +149,15 @@ Feature: Site-wide products search
       """
       Diesel (1)
       Gasoline (1)
+      """
+    And I should see 6 products in search results
+
+  @ui
+  Scenario: Searching products and viewing wheel size select attributes aggregations
+    When I browse the search page
+    And I search the products by "BMW or Volvo" phrase in the site-wide search box
+    Then I should see the following options in the "Wheel size" attribute filter:
+      """
+      18 (1)
       """
     And I should see 6 products in search results

--- a/features/shop/site_wide_searching_products_113.feature
+++ b/features/shop/site_wide_searching_products_113.feature
@@ -10,10 +10,12 @@ Feature: Site-wide products search
     And the store classifies its products as "Motorbikes"
     And the store has a select product attribute "Car Type" with values "Cabrio" and "SUV"
     And the store has a select product attribute "Motorbike Type" with values "Enduro" and "Naked"
+    And the store has a non-translatable select product attribute "Wheel size" with value "18"
     And there is a product named "BMW Z4" in the store
     And this product's price is "$42,670.00"
     And this product has select attribute "Car Type" with value "Cabrio"
     And this product has a text attribute "Color" with value "Red"
+    And this product has a select attribute "Wheel size" with value "18"
     And this product has option "Supply" with values "Gasoline" and "Diesel"
     And this product is available in "Gasoline" supply priced at "$42,670.00"
     And this product is available in "Diesel" supply priced at "$45,670.00"
@@ -147,5 +149,15 @@ Feature: Site-wide products search
       """
       Diesel (1)
       Gasoline (1)
+      """
+    And I should see 6 products in search results
+
+  @ui
+  Scenario: Searching products and viewing wheel size select attributes aggregations
+    When I browse the search page
+    And I search the products by "BMW or Volvo" phrase in the site-wide search box
+    Then I should see the following options in the "Wheel size" attribute filter:
+      """
+      18 (1)
       """
     And I should see 6 products in search results

--- a/src/PropertyBuilder/AttributeBuilder.php
+++ b/src/PropertyBuilder/AttributeBuilder.php
@@ -112,7 +112,7 @@ final class AttributeBuilder extends AbstractBuilder
         Document $document
     ): void {
         $documentKey = $this->attributeNameResolver
-            ->resolvePropertyName($attribute->getCode());
+            ->resolvePropertyName((string) $attribute->getCode());
 
         $valuesPerLocale = $this->resolveProductAttributeValuesPerLocale(
             $attribute,

--- a/src/PropertyBuilder/AttributeBuilder.php
+++ b/src/PropertyBuilder/AttributeBuilder.php
@@ -59,52 +59,51 @@ final class AttributeBuilder extends AbstractBuilder
         }
     }
 
-    private function resolveProductAttribute(
-        array $attributeConfiguration,
-        mixed $attributeValue,
+    private function resolveProductAttributeValuesPerLocale(
+        AttributeInterface $attribute,
         ProductAttributeValue $productAttribute
     ): array {
-        /** @var AttributeInterface $attribute */
-        $attribute = $productAttribute->getAttribute();
+        $value = $productAttribute->getValue();
+        if (null === $value) {
+            return [];
+        }
+
+        $values = is_array($value) ? $value : [$value];
+        $result = [];
 
         if (SelectAttributeType::TYPE === $attribute->getType()) {
-            $choices = $attributeConfiguration['choices'];
-            if (is_array($attributeValue)) {
-                foreach ($attributeValue as $i => $item) {
-                    $attributeValue[$i] = $choices[$item][$productAttribute->getLocaleCode()] ?? $item;
+            $choices = $attribute->getConfiguration()['choices'] ?? [];
+
+            if ($attribute->isTranslatable()) {
+                $locale = $productAttribute->getLocaleCode();
+                if (null === $locale) {
+                    return [];
                 }
-            } else {
-                $attributeValue = $choices[$attributeValue][$productAttribute->getLocaleCode()] ?? $attributeValue;
+
+                foreach ($values as $item) {
+                    $result[$locale][] = $choices[$item][$locale] ?? $item;
+                }
+
+                return $result;
             }
+
+            foreach ($values as $item) {
+                foreach (($choices[$item] ?? []) as $locale => $label) {
+                    $result[$locale][] = $label;
+                }
+            }
+
+            return $result;
         }
 
-        $attributes = [];
-        if (is_array($attributeValue)) {
-            foreach ($attributeValue as $singleElement) {
-                $attributes[] = $this->stringFormatter->formatToLowercaseWithoutSpaces((string) $singleElement);
-            }
-        } else {
-            switch (true) {
-                case is_string($attributeValue):
-                    $attributes[] = $this->stringFormatter->formatToLowercaseWithoutSpaces($attributeValue);
-
-                    break;
-                case $attributeValue instanceof \DateTime:
-                    $attributeFormat = $attribute->getConfiguration()['format'] ?? null;
-                    $defaultFormat = DateAttributeType::TYPE === $attribute->getStorageType() ?
-                        self::DEFAULT_DATE_FORMAT :
-                        self::DEFAULT_DATE_TIME_FORMAT
-                    ;
-
-                    $attributes[] = $attributeValue->format($attributeFormat ?? $defaultFormat);
-
-                    break;
-                default:
-                    $attributes[] = $attributeValue;
-            }
+        $locale = $productAttribute->getLocaleCode();
+        if (null === $locale) {
+            return [];
         }
 
-        return $attributes;
+        $result[$locale] = $values;
+
+        return $result;
     }
 
     private function processAttribute(
@@ -112,25 +111,49 @@ final class AttributeBuilder extends AbstractBuilder
         ProductAttributeValue $productAttribute,
         Document $document
     ): void {
-        /** @var string $attributeCode */
-        $attributeCode = $attribute->getCode();
-        $attributeConfiguration = $attribute->getConfiguration();
+        $documentKey = $this->attributeNameResolver
+            ->resolvePropertyName($attribute->getCode());
 
-        $value = $productAttribute->getValue();
-        $documentKey = $this->attributeNameResolver->resolvePropertyName($attributeCode);
-        $code = sprintf('%s_%s', $documentKey, $productAttribute->getLocaleCode());
-
-        $values = $this->resolveProductAttribute(
-            $attributeConfiguration,
-            $value,
+        $valuesPerLocale = $this->resolveProductAttributeValuesPerLocale(
+            $attribute,
             $productAttribute
         );
 
-        $values = in_array($attribute->getStorageType(), [DateAttributeType::TYPE, DatetimeAttributeType::TYPE], true) ?
-            ($values[0] ?? $values) :
-            $values
-        ;
+        foreach ($valuesPerLocale as $locale => $rawValues) {
+            $normalized = $this->normalizeValues($attribute, $rawValues);
 
-        $document->set($code, $values);
+            $document->set(
+                sprintf('%s_%s', $documentKey, $locale),
+                $normalized
+            );
+        }
+    }
+
+    private function normalizeValues(AttributeInterface $attribute, array $values): array|string
+    {
+        $normalized = array_map(function ($value) use ($attribute) {
+            if (is_string($value)) {
+                return $this->stringFormatter->formatToLowercaseWithoutSpaces($value);
+            }
+
+            if ($value instanceof \DateTimeInterface) {
+                $format = $attribute->getConfiguration()['format'] ?? null;
+                $default = DateAttributeType::TYPE === $attribute->getStorageType()
+                    ? self::DEFAULT_DATE_FORMAT
+                    : self::DEFAULT_DATE_TIME_FORMAT;
+
+                return $value->format($format ?? $default);
+            }
+
+            return $value;
+        }, $values);
+
+        return in_array(
+            $attribute->getStorageType(),
+            [DateAttributeType::TYPE, DatetimeAttributeType::TYPE],
+            true
+        )
+            ? ($normalized[0] ?? $normalized)
+            : $normalized;
     }
 }

--- a/tests/Behat/Page/Shop/SearchPage.php
+++ b/tests/Behat/Page/Shop/SearchPage.php
@@ -44,6 +44,7 @@ class SearchPage extends SymfonyPage implements SearchPageInterface
             'search_facets_filter_button' => 'form[name="bitbag_elasticsearch_search"] button[type="submit"]',
             'search_facets_attribute_car_type' => '#bitbag_elasticsearch_search_facets_Car_Type',
             'search_facets_attribute_motorbike_type' => '#bitbag_elasticsearch_search_facets_Motorbike_Type',
+            'search_facets_attribute_wheel_size' => '#bitbag_elasticsearch_search_facets_Wheel_size',
             'search_facets_attribute_color' => '#bitbag_elasticsearch_search_facets_Color',
             'search_facets_option_supply' => '#bitbag_elasticsearch_search_facets_SUPPLY',
             'search_facets_option_SUPPLY' => '#bitbag_elasticsearch_search_facets_SUPPLY',

--- a/tests/Behat/Service/Populate.php
+++ b/tests/Behat/Service/Populate.php
@@ -14,12 +14,15 @@ use FOS\ElasticaBundle\Event\PostIndexPopulateEvent;
 use FOS\ElasticaBundle\Event\PreIndexPopulateEvent;
 use FOS\ElasticaBundle\Index\IndexManager;
 use FOS\ElasticaBundle\Index\ResetterInterface;
+use FOS\ElasticaBundle\Persister\PagerPersisterInterface;
 use FOS\ElasticaBundle\Persister\PagerPersisterRegistry;
 use FOS\ElasticaBundle\Provider\PagerProviderRegistry;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class Populate
 {
+    private PagerPersisterInterface $pagerPersister;
+
     public function __construct(
         private EventDispatcherInterface $dispatcher,
         private IndexManager $indexManager,


### PR DESCRIPTION
Currently filters for attributes with type 'select' are only shown on the listing page if translatable = true.

This PR slightly cleans the logic in AttributeBuilder, and makes it possible to correctly populate select attributes with translatable = false
