### PR TITLE
Fix default product  sorting

### DIFF
--- a/spec/Controller/RequestDataHandler/ShopProductsSortDataHandlerSpec.php
+++ b/spec/Controller/RequestDataHandler/ShopProductsSortDataHandlerSpec.php
@@ -53,7 +53,7 @@ final class ShopProductsSortDataHandlerSpec extends ObjectBehavior
         $this->retrieveData([])->shouldBeEqualTo([
             'sort' => [
                 'created_at' => [
-                    'order' => SortDataHandlerInterface::SORT_ASC_INDEX,
+                    'order' => SortDataHandlerInterface::SORT_DESC_INDEX,
                     'unmapped_type' => 'keyword',
                 ],
             ],

--- a/src/Controller/RequestDataHandler/ShopProductsSortDataHandler.php
+++ b/src/Controller/RequestDataHandler/ShopProductsSortDataHandler.php
@@ -32,7 +32,7 @@ final class ShopProductsSortDataHandler implements SortDataHandlerInterface
         $data = [];
 
         $orderBy = $requestData[self::ORDER_BY_INDEX] ?? $this->createdAtProperty;
-        $sort = $requestData[self::SORT_INDEX] ?? self::SORT_ASC_INDEX;
+        $sort = $requestData[self::SORT_INDEX] ?? self::SORT_DESC_INDEX;
 
         $availableSorters = [$this->soldUnitsProperty, $this->createdAtProperty, $this->pricePropertyPrefix];
         $availableSorting = [self::SORT_ASC_INDEX, self::SORT_DESC_INDEX];


### PR DESCRIPTION
Fix default product sorting on category pages to sort by newest (created_at DESC) instead of oldest, matching the "Newest" label defined in template.