### PR TITLE
Add sort by relevance(ES score) and position

### DIFF
--- a/config/services/api/request_data_handler.xml
+++ b/config/services/api/request_data_handler.xml
@@ -3,7 +3,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="bitbag_sylius_elasticsearch_plugin.api.request_data_handler" class="BitBag\SyliusElasticsearchPlugin\Api\RequestDataHandler\RequestDataHandler">
-            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.shop_products_sort" />
+            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.search_products_sort" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.pagination" />
         </service>
     </services>

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -23,6 +23,17 @@
             <argument>%bitbag_es_shop_product_price_property_prefix%</argument>
         </service>
 
+        <service id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.taxon_products_sort" class="BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\TaxonProductsSortDataHandler">
+            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.property_name_resolver.channel_pricing" />
+            <argument type="service" id="sylius.context.channel" />
+            <argument type="service" id="bitbag.sylius_elasticsearch_plugin.context.taxon" />
+            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.property_name_resolver.taxon_position" />
+            <argument>%bitbag_es_shop_product_sold_units%</argument>
+            <argument>%bitbag_es_shop_product_created_at%</argument>
+            <argument>%bitbag_es_shop_product_price_property_prefix%</argument>
+            <argument>%bitbag_es_shop_taxon_position_property_prefix%</argument>
+        </service>
+
         <service id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.site_wide" class="BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\SiteWideDataHandler">
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.shop_products_sort" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.pagination" />
@@ -30,7 +41,7 @@
 
         <service id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.taxon" class="BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\TaxonDataHandler">
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.shop_product_list" />
-            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.shop_products_sort" />
+            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.taxon_products_sort" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.pagination" />
         </service>
     </services>

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -34,8 +34,16 @@
             <argument>%bitbag_es_shop_taxon_position_property_prefix%</argument>
         </service>
 
+        <service id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.search_products_sort" class="BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\SearchProductsSortDataHandler">
+            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.property_name_resolver.channel_pricing" />
+            <argument type="service" id="sylius.context.channel" />
+            <argument>%bitbag_es_shop_product_sold_units%</argument>
+            <argument>%bitbag_es_shop_product_created_at%</argument>
+            <argument>%bitbag_es_shop_product_price_property_prefix%</argument>
+        </service>
+
         <service id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.site_wide" class="BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\SiteWideDataHandler">
-            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.shop_products_sort" />
+            <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.search_products_sort" />
             <argument type="service" id="bitbag_sylius_elasticsearch_plugin.controller.request_data_handler.pagination" />
         </service>
 

--- a/config/twig/bitbag_twig_hooks.yml
+++ b/config/twig/bitbag_twig_hooks.yml
@@ -69,6 +69,13 @@ sylius_twig_hooks:
         template: '@SyliusShop/product/index/content/body/main/filters/controls/sorting/menu.html.twig'
         priority: 0
     'bitbag.sylius_elasticsearch_plugin.site_wide_search.index.content.body.main.filters.controls.sorting.menu':
+      relevance:
+        template: '@BitBagSyliusElasticsearchPlugin/Shop/SiteWideSearch/content/body/main/sorting/item.html.twig'
+        configuration:
+          title: 'bitbag_sylius_elasticsearch_plugin.ui.relevance'
+          order_by: 'relevance'
+          sort: 'desc'
+        priority: 700
       bestsellers:
         template: '@BitBagSyliusElasticsearchPlugin/Shop/SiteWideSearch/content/body/main/sorting/item.html.twig'
         configuration:

--- a/config/twig/bitbag_twig_hooks.yml
+++ b/config/twig/bitbag_twig_hooks.yml
@@ -167,6 +167,13 @@ sylius_twig_hooks:
         template: '@SyliusShop/product/index/content/body/main/filters/controls/sorting/menu.html.twig'
         priority: 0
     'bitbag.sylius_elasticsearch_plugin.taxon_products_search.index.content.body.main.filters.controls.sorting.menu':
+      position:
+        template: '@BitBagSyliusElasticsearchPlugin/Shop/TaxonProductsSearch/content/body/main/sorting/item.html.twig'
+        configuration:
+          title: 'bitbag_sylius_elasticsearch_plugin.ui.position'
+          order_by: 'taxon_position'
+          sort: 'asc'
+        priority: 700
       bestsellers:
         template: '@BitBagSyliusElasticsearchPlugin/Shop/TaxonProductsSearch/content/body/main/sorting/item.html.twig'
         configuration:

--- a/spec/Controller/RequestDataHandler/SearchProductsSortDataHandlerSpec.php
+++ b/spec/Controller/RequestDataHandler/SearchProductsSortDataHandlerSpec.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+*/
+
+declare(strict_types=1);
+
+namespace spec\BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler;
+
+use BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\SearchProductsSortDataHandler;
+use BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\ShopProductsSortDataHandler;
+use BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\SortDataHandlerInterface;
+use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
+
+final class SearchProductsSortDataHandlerSpec extends ObjectBehavior
+{
+    public function let(
+        ConcatedNameResolverInterface $channelPricingNameResolver,
+        ChannelContextInterface $channelContext,
+    ): void {
+        $this->beConstructedWith(
+            $channelPricingNameResolver,
+            $channelContext,
+            'sold_units',
+            'created_at',
+            'price'
+        );
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(SearchProductsSortDataHandler::class);
+    }
+
+    function it_is_a_shop_products_sort_data_handler(): void
+    {
+        $this->shouldHaveType(ShopProductsSortDataHandler::class);
+    }
+
+    function it_implements_sort_data_handler_interface(): void
+    {
+        $this->shouldHaveType(SortDataHandlerInterface::class);
+    }
+
+    function it_sorts_by_relevance_descending_by_default(): void
+    {
+        $this->retrieveData([])->shouldBeEqualTo([
+            'sort' => [
+                SearchProductsSortDataHandler::SCORE_FIELD => [
+                    'order' => SortDataHandlerInterface::SORT_DESC_INDEX,
+                ],
+            ],
+        ]);
+    }
+
+    function it_sorts_by_relevance_when_it_is_explicitly_requested(): void
+    {
+        $this->retrieveData([
+            'order_by' => SearchProductsSortDataHandler::RELEVANCE,
+            'sort' => SortDataHandlerInterface::SORT_ASC_INDEX,
+        ])->shouldBeEqualTo([
+            'sort' => [
+                SearchProductsSortDataHandler::SCORE_FIELD => [
+                    'order' => SortDataHandlerInterface::SORT_ASC_INDEX,
+                ],
+            ],
+        ]);
+    }
+
+    function it_does_not_add_unmapped_type_to_the_relevance_score(): void
+    {
+        $sort = $this->retrieveData([])['sort'];
+
+        $sort[SearchProductsSortDataHandler::SCORE_FIELD]->shouldNotHaveKey('unmapped_type');
+    }
+
+    function it_delegates_other_sorters_to_the_parent_handler(): void
+    {
+        $this->retrieveData([
+            'order_by' => 'created_at',
+            'sort' => SortDataHandlerInterface::SORT_DESC_INDEX,
+        ])->shouldBeEqualTo([
+            'sort' => [
+                'created_at' => [
+                    'order' => SortDataHandlerInterface::SORT_DESC_INDEX,
+                    'unmapped_type' => 'keyword',
+                ],
+            ],
+        ]);
+    }
+
+    function it_still_resolves_the_price_field_per_channel(
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel,
+        ConcatedNameResolverInterface $channelPricingNameResolver,
+    ): void {
+        $channelContext->getChannel()->willReturn($channel);
+        $channel->getCode()->willReturn('WEB');
+        $channelPricingNameResolver->resolvePropertyName('WEB')->willReturn('price_WEB');
+
+        $this->retrieveData([
+            'order_by' => 'price',
+            'sort' => SortDataHandlerInterface::SORT_ASC_INDEX,
+        ])->shouldBeEqualTo([
+            'sort' => [
+                'price_WEB' => [
+                    'order' => SortDataHandlerInterface::SORT_ASC_INDEX,
+                    'unmapped_type' => 'keyword',
+                ],
+            ],
+        ]);
+    }
+
+    function it_throws_an_exception_for_an_invalid_sort_direction_on_relevance(): void
+    {
+        $this->shouldThrow(\UnexpectedValueException::class)->during('retrieveData', [
+            [
+                'order_by' => SearchProductsSortDataHandler::RELEVANCE,
+                'sort' => 'sideways',
+            ],
+        ]);
+    }
+
+    function it_throws_an_exception_for_an_unsupported_sorter(): void
+    {
+        $this->shouldThrow(\UnexpectedValueException::class)->during('retrieveData', [
+            ['order_by' => 'unsupported'],
+        ]);
+    }
+}

--- a/spec/Controller/RequestDataHandler/TaxonProductsSortDataHandlerSpec.php
+++ b/spec/Controller/RequestDataHandler/TaxonProductsSortDataHandlerSpec.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+*/
+
+declare(strict_types=1);
+
+namespace spec\BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler;
+
+use BitBag\SyliusElasticsearchPlugin\Context\TaxonContextInterface;
+use BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\ShopProductsSortDataHandler;
+use BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\SortDataHandlerInterface;
+use BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler\TaxonProductsSortDataHandler;
+use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+
+final class TaxonProductsSortDataHandlerSpec extends ObjectBehavior
+{
+    public function let(
+        ConcatedNameResolverInterface $channelPricingNameResolver,
+        ChannelContextInterface $channelContext,
+        TaxonContextInterface $taxonContext,
+        ConcatedNameResolverInterface $taxonPositionNameResolver,
+    ): void {
+        $this->beConstructedWith(
+            $channelPricingNameResolver,
+            $channelContext,
+            $taxonContext,
+            $taxonPositionNameResolver,
+            'sold_units',
+            'created_at',
+            'price',
+            'taxon_position'
+        );
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(TaxonProductsSortDataHandler::class);
+    }
+
+    function it_is_a_shop_products_sort_data_handler(): void
+    {
+        $this->shouldHaveType(ShopProductsSortDataHandler::class);
+    }
+
+    function it_implements_sort_data_handler_interface(): void
+    {
+        $this->shouldHaveType(SortDataHandlerInterface::class);
+    }
+
+    function it_sorts_by_taxon_position_ascending_by_default(
+        TaxonContextInterface $taxonContext,
+        TaxonInterface $taxon,
+        ConcatedNameResolverInterface $taxonPositionNameResolver,
+    ): void {
+        $taxonContext->getTaxon()->willReturn($taxon);
+        $taxon->getCode()->willReturn('t_shirts');
+        $taxonPositionNameResolver->resolvePropertyName('t_shirts')->willReturn('taxon_position_t_shirts');
+
+        $this->retrieveData([])->shouldBeEqualTo([
+            'sort' => [
+                'taxon_position_t_shirts' => [
+                    'order' => SortDataHandlerInterface::SORT_ASC_INDEX,
+                    'unmapped_type' => 'keyword',
+                ],
+            ],
+        ]);
+    }
+
+    function it_resolves_the_taxon_position_field_for_the_current_taxon(
+        TaxonContextInterface $taxonContext,
+        TaxonInterface $taxon,
+        ConcatedNameResolverInterface $taxonPositionNameResolver,
+    ): void {
+        $taxonContext->getTaxon()->willReturn($taxon);
+        $taxon->getCode()->willReturn('mugs');
+        $taxonPositionNameResolver->resolvePropertyName('mugs')->willReturn('taxon_position_mugs');
+
+        $this->retrieveData([
+            'order_by' => 'taxon_position',
+            'sort' => 'desc',
+        ])->shouldBeEqualTo([
+            'sort' => [
+                'taxon_position_mugs' => [
+                    'order' => SortDataHandlerInterface::SORT_DESC_INDEX,
+                    'unmapped_type' => 'keyword',
+                ],
+            ],
+        ]);
+    }
+
+    function it_still_resolves_the_price_field_per_channel(
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel,
+        ConcatedNameResolverInterface $channelPricingNameResolver,
+    ): void {
+        $channelContext->getChannel()->willReturn($channel);
+        $channel->getCode()->willReturn('WEB');
+        $channelPricingNameResolver->resolvePropertyName('WEB')->willReturn('price_WEB');
+
+        $this->retrieveData([
+            'order_by' => 'price',
+            'sort' => 'asc',
+        ])->shouldBeEqualTo([
+            'sort' => [
+                'price_WEB' => [
+                    'order' => SortDataHandlerInterface::SORT_ASC_INDEX,
+                    'unmapped_type' => 'keyword',
+                ],
+            ],
+        ]);
+    }
+
+    function it_throws_an_exception_for_an_unsupported_sorter(): void
+    {
+        $this->shouldThrow(\UnexpectedValueException::class)->during('retrieveData', [
+            ['order_by' => 'unsupported'],
+        ]);
+    }
+}

--- a/src/Api/OpenApi/Documentation/ProductSearchDocumentationModifier.php
+++ b/src/Api/OpenApi/Documentation/ProductSearchDocumentationModifier.php
@@ -70,7 +70,7 @@ final class ProductSearchDocumentationModifier implements OpenApiFactoryInterfac
                 required: false,
                 deprecated: false,
                 allowEmptyValue: false,
-                schema: ['type' => 'string', 'enum' => ['sold_units', 'product_created_at', 'price']],
+                schema: ['type' => 'string', 'enum' => ['relevance', 'sold_units', 'product_created_at', 'price']],
             ),
 
             new Parameter(

--- a/src/Controller/RequestDataHandler/SearchProductsSortDataHandler.php
+++ b/src/Controller/RequestDataHandler/SearchProductsSortDataHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.io and write us
+ * an email on hello@bitbag.io.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler;
+
+use UnexpectedValueException;
+
+final class SearchProductsSortDataHandler extends ShopProductsSortDataHandler
+{
+    public const RELEVANCE = 'relevance';
+
+    public const SCORE_FIELD = '_score';
+
+    public function retrieveData(array $requestData): array
+    {
+        $orderBy = $requestData[self::ORDER_BY_INDEX] ?? $this->getDefaultOrderBy();
+
+        if (self::RELEVANCE === $orderBy) {
+            $sort = $requestData[self::SORT_INDEX] ?? self::SORT_DESC_INDEX;
+
+            if (!in_array($sort, [self::SORT_ASC_INDEX, self::SORT_DESC_INDEX], true)) {
+                throw new UnexpectedValueException();
+            }
+
+            return ['sort' => [self::SCORE_FIELD => ['order' => strtolower($sort)]]];
+        }
+
+        return parent::retrieveData($requestData);
+    }
+
+    protected function getDefaultOrderBy(): string
+    {
+        return self::RELEVANCE;
+    }
+}

--- a/src/Controller/RequestDataHandler/ShopProductsSortDataHandler.php
+++ b/src/Controller/RequestDataHandler/ShopProductsSortDataHandler.php
@@ -16,14 +16,14 @@ use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverIn
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use UnexpectedValueException;
 
-final class ShopProductsSortDataHandler implements SortDataHandlerInterface
+class ShopProductsSortDataHandler implements SortDataHandlerInterface
 {
     public function __construct(
-        private ConcatedNameResolverInterface $channelPricingNameResolver,
-        private ChannelContextInterface $channelContext,
-        private string $soldUnitsProperty,
-        private string $createdAtProperty,
-        private string $pricePropertyPrefix
+        protected ConcatedNameResolverInterface $channelPricingNameResolver,
+        protected ChannelContextInterface $channelContext,
+        protected string $soldUnitsProperty,
+        protected string $createdAtProperty,
+        protected string $pricePropertyPrefix
     ) {
     }
 
@@ -31,24 +31,43 @@ final class ShopProductsSortDataHandler implements SortDataHandlerInterface
     {
         $data = [];
 
-        $orderBy = $requestData[self::ORDER_BY_INDEX] ?? $this->createdAtProperty;
+        $orderBy = $requestData[self::ORDER_BY_INDEX] ?? $this->getDefaultOrderBy();
         $sort = $requestData[self::SORT_INDEX] ?? self::SORT_ASC_INDEX;
 
-        $availableSorters = [$this->soldUnitsProperty, $this->createdAtProperty, $this->pricePropertyPrefix];
         $availableSorting = [self::SORT_ASC_INDEX, self::SORT_DESC_INDEX];
 
-        if (!in_array($orderBy, $availableSorters, true) || !in_array($sort, $availableSorting, true)) {
+        if (!in_array($orderBy, $this->getAvailableSorters(), true) || !in_array($sort, $availableSorting, true)) {
             throw new UnexpectedValueException();
         }
 
+        $orderBy = $this->resolveOrderByProperty($orderBy);
+
+        $data['sort'] = [$orderBy => ['order' => strtolower($sort), 'unmapped_type' => 'keyword']];
+
+        return $data;
+    }
+
+    protected function getDefaultOrderBy(): string
+    {
+        return $this->createdAtProperty;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getAvailableSorters(): array
+    {
+        return [$this->soldUnitsProperty, $this->createdAtProperty, $this->pricePropertyPrefix];
+    }
+
+    protected function resolveOrderByProperty(string $orderBy): string
+    {
         if ($this->pricePropertyPrefix === $orderBy) {
             /** @var string $channelCode */
             $channelCode = $this->channelContext->getChannel()->getCode();
             $orderBy = $this->channelPricingNameResolver->resolvePropertyName($channelCode);
         }
 
-        $data['sort'] = [$orderBy => ['order' => strtolower($sort), 'unmapped_type' => 'keyword']];
-
-        return $data;
+        return $orderBy;
     }
 }

--- a/src/Controller/RequestDataHandler/TaxonProductsSortDataHandler.php
+++ b/src/Controller/RequestDataHandler/TaxonProductsSortDataHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.io and write us
+ * an email on hello@bitbag.io.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusElasticsearchPlugin\Controller\RequestDataHandler;
+
+use BitBag\SyliusElasticsearchPlugin\Context\TaxonContextInterface;
+use BitBag\SyliusElasticsearchPlugin\PropertyNameResolver\ConcatedNameResolverInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+
+final class TaxonProductsSortDataHandler extends ShopProductsSortDataHandler
+{
+    public function __construct(
+        ConcatedNameResolverInterface $channelPricingNameResolver,
+        ChannelContextInterface $channelContext,
+        private TaxonContextInterface $taxonContext,
+        private ConcatedNameResolverInterface $taxonPositionNameResolver,
+        string $soldUnitsProperty,
+        string $createdAtProperty,
+        string $pricePropertyPrefix,
+        private string $taxonPositionPropertyPrefix
+    ) {
+        parent::__construct(
+            $channelPricingNameResolver,
+            $channelContext,
+            $soldUnitsProperty,
+            $createdAtProperty,
+            $pricePropertyPrefix
+        );
+    }
+
+    protected function getDefaultOrderBy(): string
+    {
+        return $this->taxonPositionPropertyPrefix;
+    }
+
+    protected function getAvailableSorters(): array
+    {
+        return array_merge(parent::getAvailableSorters(), [$this->taxonPositionPropertyPrefix]);
+    }
+
+    protected function resolveOrderByProperty(string $orderBy): string
+    {
+        if ($this->taxonPositionPropertyPrefix === $orderBy) {
+            /** @var string $taxonCode */
+            $taxonCode = $this->taxonContext->getTaxon()->getCode();
+
+            return $this->taxonPositionNameResolver->resolvePropertyName($taxonCode);
+        }
+
+        return parent::resolveOrderByProperty($orderBy);
+    }
+}

--- a/templates/Shop/SiteWideSearch/content/body/main/sorting.html.twig
+++ b/templates/Shop/SiteWideSearch/content/body/main/sorting.html.twig
@@ -3,8 +3,8 @@
     {% set route = app.request.attributes.get('_route') %}
     {% set route_parameters = app.request.query.all|unset_elements(['order_by', 'sort', 'page']) %}
 
-    {% if app.request.query.all()['order_by'] is not defined or app.request.query.all()['order_by'] is empty %}
-        {% set current_sorting_label = 'bitbag_sylius_elasticsearch_plugin.ui.newest'|trans|lower %}
+    {% if app.request.query.all()['order_by'] is not defined or app.request.query.all()['order_by'] is empty or app.request.query.all()['order_by'] == 'relevance' %}
+        {% set current_sorting_label = 'bitbag_sylius_elasticsearch_plugin.ui.relevance'|trans|lower %}
     {% elseif app.request.query.all()['order_by'] == 'sold_units'%}
         {% set current_sorting_label = 'bitbag_sylius_elasticsearch_plugin.ui.bestsellers'|trans|lower %}
     {% elseif app.request.query.all()['order_by'] == 'product_created_at' and app.request.query.all()['sort'] == 'desc'%}

--- a/templates/Shop/TaxonProductsSearch/content/body/main/sorting.html.twig
+++ b/templates/Shop/TaxonProductsSearch/content/body/main/sorting.html.twig
@@ -4,7 +4,9 @@
     {% set route_parameters = app.request.query.all|unset_elements(['order_by', 'sort', 'page']) %}
 
     {% if app.request.query.all()['order_by'] is not defined or app.request.query.all()['order_by'] is empty %}
-        {% set current_sorting_label = 'bitbag_sylius_elasticsearch_plugin.ui.newest'|trans|lower %}
+        {% set current_sorting_label = 'bitbag_sylius_elasticsearch_plugin.ui.position'|trans|lower %}
+    {% elseif app.request.query.all()['order_by'] == 'taxon_position' %}
+        {% set current_sorting_label = 'bitbag_sylius_elasticsearch_plugin.ui.position'|trans|lower %}
     {% elseif app.request.query.all()['order_by'] == 'sold_units'%}
         {% set current_sorting_label = 'bitbag_sylius_elasticsearch_plugin.ui.bestsellers'|trans|lower %}
     {% elseif app.request.query.all()['order_by'] == 'product_created_at' and app.request.query.all()['sort'] == 'desc'%}

--- a/translations/messages.ar.yml
+++ b/translations/messages.ar.yml
@@ -5,6 +5,7 @@ bitbag_sylius_elasticsearch_plugin:
         filter_results: فلترة النتائج
         filter: فلترة
         sort: ترتيب حسب
+        relevance: الصلة
         bestsellers: الأفضل مبيعا
         newest: الأحدث
         oldest: الأقدم

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -5,6 +5,7 @@ bitbag_sylius_elasticsearch_plugin:
         filter_results: Filtrace
         filter: Filtrovat
         sort: Řazení
+        relevance: Relevance
         bestsellers: Nejprodávanější
         newest: Nejnovější
         oldest: Nejstarší

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -5,6 +5,7 @@ bitbag_sylius_elasticsearch_plugin:
         filter_results: Filter results
         filter: Filter
         sort: Sort by
+        position: Position
         bestsellers: Bestsellers
         newest: Newest
         oldest: Oldest

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -6,6 +6,7 @@ bitbag_sylius_elasticsearch_plugin:
         filter: Filter
         sort: Sort by
         position: Position
+        relevance: Relevance
         bestsellers: Bestsellers
         newest: Newest
         oldest: Oldest

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -5,6 +5,7 @@ bitbag_sylius_elasticsearch_plugin:
         filter_results: Filtrer les résultats
         filter: Filtrer
         sort: Trier par
+        relevance: Pertinence
         bestsellers: Meilleures ventes
         newest: Plus récent en premier
         oldest: Plus ancien en premier

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -5,6 +5,7 @@ bitbag_sylius_elasticsearch_plugin:
         filter_results: Filter resultaten
         filter: Filter
         sort: Sorteer op
+        relevance: Relevantie
         bestsellers: Bestsellers
         newest: Nieuwste
         oldest: Oudste


### PR DESCRIPTION
 ### Taxon position sorting
  - Restores **position** as the default sort on taxon product pages (`/taxons/{slug}`).
  - Added the **Position** label to the taxon sorting dropdown.

  ### Default search sorting by relevance
  - On `/search` (shop UI **and** API), results now default to **Elasticsearch relevance** (`_score`) instead of newest-first.
  - Added `SearchProductsSortDataHandler` (extends the base above); all other sorters delegate to the parent unchanged.
  - Added a **Relevance** option to the sort dropdown and fixed the sort-label template (it lacked a `relevance`/`position` case →
  crashed on select; the default label now reflects the real default sort).
  - API: `order_by=relevance` added to the OpenAPI `order_by` enum.
  - Added `ui.relevance` and `ui.position` translations.

  ### Tests
  - New phpspec specs for `TaxonProductsSortDataHandler` and `SearchProductsSortDataHandler`.
  - Existing phpspec + PHPUnit suites pass (no snapshot regressions).